### PR TITLE
Adapt to WeChat playable Mode.

### DIFF
--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -195,22 +195,15 @@ function define (className, baseClass, options): any {
                 renderName = 'render_stage';
             }
             // 增加了 hidden: 开头标识，使它最终不会显示在 Editor inspector 的添加组件列表里
-            if (globalThis.EditorExtends) {
-                globalThis.EditorExtends.Component.addMenu(cls, `hidden:${renderName}/${className}`, -1);
-            }
+
+            window.EditorExtends && window.EditorExtends.Component.addMenu(cls, `hidden:${renderName}/${className}`, -1);
         }
 
         // Note: `options.ctor` should be the same as `cls` except if
         // cc-class is defined by `cc.Class({/* ... */})`.
         // In such case, `options.ctor` may be `undefined`.
         // So we can not use `options.ctor`. Instead, we should use `cls` which is the "real" registered cc-class.
-        // Emit via globalThis.EditorExtends to ensure the event reaches
-        // both the engine-internal and the scene-bundle event systems.
-        if (globalThis.EditorExtends) {
-            globalThis.EditorExtends.emit('class-registered', cls, frame, className);
-        } else {
-            EditorExtends.emit('class-registered', cls, frame, className);
-        }
+        EditorExtends.emit('class-registered', cls, frame, className);
     }
 
     if (frame) {


### PR DESCRIPTION
related PR:  https://github.com/cocos/cocos-pal-wechat-playable/pull/3

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
