### PR TITLE
feat(node): 使setWorldPosition方法的z参数变为可选参数

### DIFF
--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -2616,7 +2616,7 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
      * @param y Y axis position
      * @param z Z axis position
      */
-    public setWorldPosition(x: number, y: number, z: number): void;
+    public setWorldPosition(x: number, y: number, z?: number): void;
 
     public setWorldPosition (val: Vec3 | number, y?: number, z?: number): void {
         const worldPosition = this._pos;
@@ -2624,6 +2624,10 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
         if (y === undefined) {
             Vec3.copy(worldPosition, val as Vec3);
         } else {
+            if (z === undefined) {
+                z = worldPosition.z;
+            }
+
             Vec3.set(worldPosition, val as number, y, z!);
         }
 

--- a/cocos/scene-graph/node.ts
+++ b/cocos/scene-graph/node.ts
@@ -2628,7 +2628,7 @@ export class Node extends CCObject implements ISchedulable, CustomSerializable {
                 z = worldPosition.z;
             }
 
-            Vec3.set(worldPosition, val as number, y, z!);
+            Vec3.set(worldPosition, val as number, y, z);
         }
 
         const parent = this._parent;


### PR DESCRIPTION
使Node类的setWorldPosition方法的z轴参数变为可选参数，当z参数未提供时，
默认使用当前节点的世界位置的z值。这增强了API的灵活性，允许开发者在
设置世界位置时只指定x和y坐标。

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
