### PR TITLE
renderEntityType 等于 RenderEntityType.CROSSED 时, 不再处理子节点.

### DIFF
--- a/cocos/2d/renderer/batcher-2d.ts
+++ b/cocos/2d/renderer/batcher-2d.ts
@@ -940,7 +940,12 @@ export class Batcher2D implements IBatcher {
                 }
             }
 
-            if (children.length > 0 && !node._static) {
+            let breakWalk = false;
+            const entity = render ? render.renderEntity : null;
+            if (entity && entity.renderEntityType === RenderEntityType.CROSSED) {
+                breakWalk = true;
+            }
+            if (!breakWalk && children.length > 0 && !node._static) {
                 for (let i = 0; i < children.length; ++i) {
                     const child = children[i];
                     this.walk(child, level);


### PR DESCRIPTION
这个 PR 是为了确保 web/小游戏 端 与 原生端逻辑一致.
原生代码里有类似逻辑.

<img width="963" height="329" alt="image" src="https://github.com/user-attachments/assets/a282e863-0c01-4133-9296-beb50ab99c71" />

虽然不明白 cocos 为什么这么设计, 以及 这个 CROSSED 到底啥意思.

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
