### PR TITLE
优化执行 `node->_setColorDirty(false)`的时机

### DIFF
--- a/native/cocos/2d/renderer/Batcher2d.cpp
+++ b/native/cocos/2d/renderer/Batcher2d.cpp
@@ -272,7 +272,7 @@ void Batcher2d::walk(Node* node, float parentOpacity, bool parentColorDirty) { /
         }
     }
     
-    if (isCurrentColorDirty) {
+    if (isCurrentColorDirty && (!entity || visible && entity->isEnabled())) {
         node->_setColorDirty(false);
     }
 


### PR DESCRIPTION
只有在  colorDirty 真正发挥过作用后 ,再执行 node->_setColorDirty(false).

目前的逻辑存在一个 bug:

某帧:
- node.colorDirty=true,
- 但是 entity.isEnabled === false,
- 那么 entity 的 透明度并不会被更新.
- 可是在这一帧  node.colorDirty 仍然被设置为了 false.

下一帧:
-  entity.isEnabled  === true 了,
- 但是 node.colorDirty  在上一帧已经被设置为 false
- 当前帧 entity 的 透明度仍然不会被更新

其实 cocos在 ts 端的逻辑也是 只有 visible 时, 才去修改 opacityDirty .

-----

我在实际项目中遇到的现象是
对 某个当前不可用 的 label 节点设置 透明度 , 当节点可用时 之前设置的透明度无效.

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
