### PR TITLE
Refactor MiddlewareManager::render to use updateOperateCache

### DIFF
--- a/native/cocos/editor-support/MiddlewareManager.cpp
+++ b/native/cocos/editor-support/MiddlewareManager.cpp
@@ -90,12 +90,7 @@ void MiddlewareManager::update(float dt) {
 void MiddlewareManager::render(float dt) {
     // Object._deferredDestroy is called after component update in Director.tick and before emitting BEFORE_DRAW event in which MiddlewareManager::render is invoked, 
     // so the native object may be released here and it needs to be erased from _updateList.
-    for (auto &iter : _operateCacheQueue) {
-        auto it = std::find(_updateList.begin(), _updateList.end(), iter.first);
-        if (!iter.second && it != _updateList.end()) {
-            _updateList.erase(it);
-        }
-    }
+    updateOperateCache();
 
     for (auto it : _mbMap) {
         auto *buffer = it.second;


### PR DESCRIPTION
Replaced the loop for erasing items from _updateList with a call to updateOperateCache.

之前的版本 , 只处理了 "移除对象" 的情况, 如果在  MiddlewareManager::update之后 MiddlewareManager::render 之前的游戏逻辑中, 有 把某个 spine对象设置为 enabled = true, 或者 羡 false 再true 的情况, 就不能被正确处理了.

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
