### PR TITLE
Fix the flickering issue in Spine that may occur when setting false first and then true within the same frame.

### DIFF
--- a/native/cocos/editor-support/MiddlewareManager.cpp
+++ b/native/cocos/editor-support/MiddlewareManager.cpp
@@ -55,7 +55,18 @@ MeshBuffer *MiddlewareManager::getMeshBuffer(int format) {
 }
 
 void MiddlewareManager::updateOperateCache() {
-    for (const auto &op : _operateCacheQueue) {
+    if (_operateCacheQueue.empty()) return;
+
+    ccstd::vector<IMiddleware*> seen;
+    ccstd::vector<std::pair<IMiddleware*, bool>> finalOperations;
+    for (auto it = _operateCacheQueue.rbegin(); it != _operateCacheQueue.rend(); ++it) {
+        if (std::find(seen.begin(), seen.end(), it->first) == seen.end()) {
+            seen.push_back(it->first);
+            finalOperations.emplace_back(it->first, it->second);
+        }
+    }
+
+    for (const auto &op : finalOperations) {
         IMiddleware *editor = op.first;
         bool isAddOperation = op.second;
 
@@ -88,12 +99,19 @@ void MiddlewareManager::update(float dt) {
 }
 
 void MiddlewareManager::render(float dt) {
-    // Object._deferredDestroy is called after component update in Director.tick and before emitting BEFORE_DRAW event in which MiddlewareManager::render is invoked, 
-    // so the native object may be released here and it needs to be erased from _updateList.
-    for (auto &iter : _operateCacheQueue) {
-        auto it = std::find(_updateList.begin(), _updateList.end(), iter.first);
-        if (!iter.second && it != _updateList.end()) {
-            _updateList.erase(it);
+    ccstd::vector<IMiddleware*> skipRenderList;
+    if (!_operateCacheQueue.empty()) {
+        ccstd::vector<IMiddleware*> seen;
+        // Object._deferredDestroy is called after component update in Director.tick and before emitting BEFORE_DRAW event in which MiddlewareManager::render is invoked, 
+        // so the native object may be released here.
+        // We shouldn't execute editor->render(dt) if it's already removed in _operateCacheQueue.
+        for (auto it = _operateCacheQueue.rbegin(); it != _operateCacheQueue.rend(); ++it) {
+            if (std::find(seen.begin(), seen.end(), it->first) == seen.end()) {
+                seen.push_back(it->first);
+                if (!it->second) {
+                    skipRenderList.push_back(it->first);
+                }
+            }
         }
     }
 
@@ -106,6 +124,9 @@ void MiddlewareManager::render(float dt) {
 
     for (size_t i = 0, len = _updateList.size(); i < len; ++i) {
         auto *editor = _updateList[i];
+        if (!skipRenderList.empty() && std::find(skipRenderList.begin(), skipRenderList.end(), editor) != skipRenderList.end()) {
+            continue;
+        }
         editor->render(dt);
     }
 


### PR DESCRIPTION
Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
