### PR TITLE
解决cocos在字节小游戏上下载文件，每隔2秒掉帧到30-40帧的问题。原因是_write方法里使用writeFileSync方法在字节小…

### DIFF
--- a/platforms/minigame/common/engine/cache-manager.js
+++ b/platforms/minigame/common/engine/cache-manager.js
@@ -24,12 +24,15 @@
  ****************************************************************************/
 const {
     getUserDataPath, readJsonSync, makeDirSync,
-    writeFileSync, copyFile, downloadFile, deleteFile,
+    writeFileSync, writeFile, copyFile, downloadFile, deleteFile,
     rmdirSync, unzip, isOutOfStorage,
 } = window.fsUtils;
 
 let checkNextPeriod = false;
 let writeCacheFileList = null;
+let startWrite = false;
+let nextCallbacks = [];
+let callbacks = [];
 let cleaning = false;
 let suffix = 0;
 const REGEX = /^https?:\/\/.*/;
@@ -96,58 +99,74 @@ const cacheManager = {
 
     _write () {
         writeCacheFileList = null;
-        writeFileSync(`${this.cacheDir}/${this.cachedFileName}`, JSON.stringify({ files: this.cachedFiles._map, version: this.version }), 'utf8');
+        startWrite = true;
+        writeFile(this.cacheDir + '/' + this.cachedFileName, JSON.stringify({ files: this.cachedFiles._map, version: this.version }), 'utf8', function () {
+            startWrite = false;
+            for (let i = 0, j = callbacks.length; i < j; i++) {
+                callbacks[i]();
+            }
+            callbacks.length = 0;
+            callbacks.push.apply(callbacks, nextCallbacks);
+            nextCallbacks.length = 0;
+        });
     },
 
-    writeCacheFile () {
+    writeCacheFile (cb) {
         if (!writeCacheFileList) {
             writeCacheFileList = setTimeout(this._write.bind(this), this.writeFileInterval);
+            if (startWrite === true) {
+                cb && nextCallbacks.push(cb);
+            }
+            else {
+                cb && callbacks.push(cb);
+            }
+        } else {
+            cb && callbacks.push(cb);
         }
     },
 
     _cache () {
-        checkNextPeriod = false;
         const self = this;
-        let id = '';
-        // eslint-disable-next-line no-unreachable-loop
-        for (const key in this.cacheQueue) {
-            id = key;
-            break;
-        }
-        if (!id) return;
-        const { srcUrl, isCopy, cacheBundleRoot } = this.cacheQueue[id];
-        const time = Date.now().toString();
+        for (const id in this.cacheQueue) {
+            const { srcUrl, isCopy, cacheBundleRoot } = this.cacheQueue[id];
+            const time = Date.now().toString();
 
-        let localPath = '';
+            let localPath = '';
 
-        if (cacheBundleRoot) {
-            localPath = `${this.cacheDir}/${cacheBundleRoot}/${time}${suffix++}${cc.path.extname(id)}`;
-        } else {
-            localPath = `${this.cacheDir}/${time}${suffix++}${cc.path.extname(id)}`;
-        }
-
-        function callback (err) {
-            if (err)  {
-                if (isOutOfStorage(err.message)) {
-                    self.outOfStorage = true;
-                    self.autoClear && self.clearLRU();
-                    return;
+            if (cacheBundleRoot) {
+                localPath = `${this.cacheDir}/${cacheBundleRoot}/${time}${suffix++}${cc.path.extname(id)}`;
+            }
+            else {
+                localPath = `${this.cacheDir}/${time}${suffix++}${cc.path.extname(id)}`;
+            }
+            
+            function callback (err) {
+                checkNextPeriod = false;
+                if (err)  {
+                    if (isOutOfStorage(err.message)) {
+                        self.outOfStorage = true;
+                        self.autoClear && self.clearLRU();
+                        return;
+                    }
+                } else {
+                    self.cachedFiles.add(id, { bundle: cacheBundleRoot, url: localPath, lastTime: time });
+                    delete self.cacheQueue[id];
+                    self.writeCacheFile();
                 }
-            } else {
-                self.cachedFiles.add(id, { bundle: cacheBundleRoot, url: localPath, lastTime: time });
-                self.writeCacheFile();
+                if (!cc.js.isEmptyObject(self.cacheQueue)) {
+                    checkNextPeriod = true;
+                    setTimeout(self._cache.bind(self), self.cacheInterval);
+                }
             }
-            delete self.cacheQueue[id];
-            if (!cc.js.isEmptyObject(self.cacheQueue) && !checkNextPeriod) {
-                checkNextPeriod = true;
-                setTimeout(self._cache.bind(self), self.cacheInterval);
+            if (!isCopy) {
+                downloadFile(srcUrl, localPath, null, callback);
             }
+            else {
+                copyFile(srcUrl, localPath, callback);
+            }
+            return;
         }
-        if (!isCopy) {
-            downloadFile(srcUrl, localPath, null, callback);
-        } else {
-            copyFile(srcUrl, localPath, callback);
-        }
+        checkNextPeriod = false;
     },
 
     cacheFile (id, srcUrl, cacheEnabled, cacheBundleRoot, isCopy) {
@@ -155,9 +174,14 @@ const cacheManager = {
         if (!cacheEnabled || this.cacheQueue[id] || this.cachedFiles.has(id)) return;
 
         this.cacheQueue[id] = { srcUrl, cacheBundleRoot, isCopy };
-        if (!checkNextPeriod && !this.outOfStorage) {
+        if (!checkNextPeriod) {
             checkNextPeriod = true;
-            setTimeout(this._cache.bind(this), this.cacheInterval);
+            if (!this.outOfStorage) {
+                setTimeout(this._cache.bind(this), this.cacheInterval);
+            }
+            else {
+                checkNextPeriod = false;
+            }
         }
     },
 
@@ -165,10 +189,12 @@ const cacheManager = {
         rmdirSync(this.cacheDir, true);
         this.cachedFiles = new cc.AssetManager.Cache();
         makeDirSync(this.cacheDir, true);
+        const cacheFilePath = this.cacheDir + '/' + this.cachedFileName;
         this.outOfStorage = false;
         clearTimeout(writeCacheFileList);
-        this._write();
-        cc.assetManager.bundles.forEach((bundle) => {
+        writeCacheFileList = null;
+        writeFileSync(cacheFilePath, JSON.stringify({ files: this.cachedFiles._map, version: this.version }), 'utf8');
+        cc.assetManager.bundles.forEach(bundle => {
             if (REGEX.test(bundle.base)) this.makeBundleFolder(bundle.name);
         });
     },
@@ -194,27 +220,33 @@ const cacheManager = {
             cc.assetManager.files.remove(cacheKey);
             this.cachedFiles.remove(caches[i].originUrl);
         }
-
+        
         clearTimeout(writeCacheFileList);
-        this._write();
-        function deferredDelete () {
-            const item = caches.pop();
-            self._removePathOrFile(item.originUrl, item.url);
-            if (caches.length > 0) {
-                setTimeout(deferredDelete, self.deleteInterval);
-            } else {
-                cleaning = false;
+        writeCacheFileList = null;
+        this.writeCacheFile(function () {
+            function deferredDelete () {
+                const item = caches.pop();
+                self._removePathOrFile(item.originUrl, item.url);
+                if (caches.length > 0) { 
+                    setTimeout(deferredDelete, self.deleteInterval); 
+                }
+                else {
+                    cleaning = false;
+                }
             }
-        }
-        setTimeout(deferredDelete, self.deleteInterval);
+            setTimeout(deferredDelete, self.deleteInterval);
+        });
     },
 
     removeCache (url) {
         if (this.cachedFiles.has(url)) {
+            const self = this;
             const path = this.cachedFiles.remove(url).url;
             clearTimeout(writeCacheFileList);
-            this._write();
-            this._removePathOrFile(url, path);
+            writeCacheFileList = null;
+            this.writeCacheFile(function () {
+                self._removePathOrFile(url, path);
+            });
         }
     },
 


### PR DESCRIPTION
…游戏上可能时长700ms，卡主游戏。修改方法是改成2.x的版本使用异步方法writeFile，cache-manager基本改成和2.4.16一样了

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
