### PR TITLE
[功能][Spine] 补完 spine 4.2 的 PhysicsConstraint wasm 绑定

### DIFF
--- a/cocos/spine/lib/spine-core.d.ts
+++ b/cocos/spine/lib/spine-core.d.ts
@@ -42,6 +42,24 @@ declare namespace spine {
         delete();
     }
 
+    /**
+     * @version 4.2
+     */
+    class SPVectorPhysicsConstraintPtr {
+        size(): number;
+        get(index: number): PhysicsConstraint;
+        delete();
+    }
+
+    /**
+     * @version 4.2
+     */
+    class SPVectorPhysicsConstraintDataPtr {
+        size(): number;
+        get(index: number): PhysicsConstraintData;
+        delete();
+    }
+
     class Animation {
         constructor(name: string, timelines: Array<Timeline>, duration: number);
         duration: number;
@@ -708,6 +726,10 @@ declare namespace spine {
         ikConstraints: Array<IkConstraint>;
         transformConstraints: Array<TransformConstraint>;
         pathConstraints: Array<PathConstraint>;
+        /**
+         * @version 4.2
+         */
+        physicsConstraints: Array<PhysicsConstraint>;
         _updateCache: Updatable[];
         skin: Skin;
         color: Color;
@@ -735,8 +757,24 @@ declare namespace spine {
         findIkConstraint(constraintName: string): IkConstraint;
         findTransformConstraint(constraintName: string): TransformConstraint;
         findPathConstraint(constraintName: string): PathConstraint;
+        /**
+         * @version 4.2
+         */
+        findPhysicsConstraint(constraintName: string): PhysicsConstraint;
+        /**
+         * @version 4.2
+         */
+        getPhysicsConstraints(): SPVectorPhysicsConstraintPtr;
         //getBounds(offset: Vector2, size: Vector2, temp?: Array<number>): void;
         update(delta: number): void;
+        /**
+         * @version 4.2
+         */
+        updateWorldTransform(physics: Physics): void;
+        /**
+         * @version 4.2
+         */
+        updateWorldTransform(physics: Physics, parent: Bone): void;
     }
     class SkeletonBinary {
         static AttachmentTypeValues: number[];
@@ -812,6 +850,10 @@ declare namespace spine {
         ikConstraints: IkConstraintData[];
         transformConstraints: TransformConstraintData[];
         pathConstraints: PathConstraintData[];
+        /**
+         * @version 4.2
+         */
+        physicsConstraints: PhysicsConstraintData[];
         x: number;
         y: number;
         width: number;
@@ -835,6 +877,14 @@ declare namespace spine {
         findTransformConstraint(constraintName: string): TransformConstraintData;
         findPathConstraint(constraintName: string): PathConstraintData;
         findPathConstraintIndex(pathConstraintName: string): number;
+        /**
+         * @version 4.2
+         */
+        findPhysicsConstraint(constraintName: string): PhysicsConstraintData;
+        /**
+         * @version 4.2
+         */
+        getPhysicsConstraints(): SPVectorPhysicsConstraintDataPtr;
     }
     class SkeletonJson {
         attachmentLoader: AttachmentLoader;
@@ -1003,6 +1053,82 @@ declare namespace spine {
         offsetShearY: number;
         relative: boolean;
         local: boolean;
+        constructor(name: string);
+    }
+    /**
+     * @version 4.2
+     */
+    enum Physics {
+        none = 0,
+        reset = 1,
+        update = 2,
+        pose = 3
+    }
+    /**
+     * @version 4.2
+     */
+    class PhysicsConstraint implements Updatable {
+        data: PhysicsConstraintData;
+        bone: Bone;
+        inertia: number;
+        strength: number;
+        damping: number;
+        massInverse: number;
+        wind: number;
+        gravity: number;
+        mix: number;
+        _reset: boolean;
+        ux: number;
+        uy: number;
+        cx: number;
+        cy: number;
+        tx: number;
+        ty: number;
+        xOffset: number;
+        xVelocity: number;
+        yOffset: number;
+        yVelocity: number;
+        rotateOffset: number;
+        rotateVelocity: number;
+        scaleOffset: number;
+        scaleVelocity: number;
+        remaining: number;
+        lastTime: number;
+        active: boolean;
+        constructor(data: PhysicsConstraintData, skeleton: Skeleton);
+        isActive(): boolean;
+        reset(): void;
+        setToSetupPose(): void;
+        update(): void;
+        translate(x: number, y: number): void;
+        rotate(x: number, y: number, degrees: number): void;
+    }
+    /**
+     * @version 4.2
+     */
+    class PhysicsConstraintData extends ConstraintData {
+        bone: BoneData;
+        x: number;
+        y: number;
+        rotate: number;
+        scaleX: number;
+        shearX: number;
+        limit: number;
+        step: number;
+        inertia: number;
+        strength: number;
+        damping: number;
+        massInverse: number;
+        wind: number;
+        gravity: number;
+        mix: number;
+        inertiaGlobal: boolean;
+        strengthGlobal: boolean;
+        dampingGlobal: boolean;
+        massGlobal: boolean;
+        windGlobal: boolean;
+        gravityGlobal: boolean;
+        mixGlobal: boolean;
         constructor(name: string);
     }
     class Triangulator {

--- a/native/cocos/editor-support/spine-wasm/4.2/spine-type-export.cpp
+++ b/native/cocos/editor-support/spine-wasm/4.2/spine-type-export.cpp
@@ -33,6 +33,7 @@ using SPVectorIkConstraintPtr = Vector<IkConstraint*>;
 using SPVectorIkConstraintDataPtr = Vector<IkConstraintData*>;
 using SPVectorTransformConstraintPtr = Vector<TransformConstraint*>;
 using SPVectorPathConstraintPtr = Vector<PathConstraint*>;
+using SPVectorPhysicsConstraintPtr = Vector<PhysicsConstraint*>;
 using SPVectorTimelinePtr = Vector<Timeline*>;
 using SPVectorTrackEntryPtr = Vector<TrackEntry*>;
 using SPVectorUpdatablePtr = Vector<Updatable*>;
@@ -207,6 +208,8 @@ DEFINE_ALLOW_RAW_POINTER(TrackEntry)
 DEFINE_ALLOW_RAW_POINTER(IkConstraintData)
 DEFINE_ALLOW_RAW_POINTER(PathConstraintData)
 DEFINE_ALLOW_RAW_POINTER(TransformConstraintData)
+DEFINE_ALLOW_RAW_POINTER(PhysicsConstraintData)
+DEFINE_ALLOW_RAW_POINTER(PhysicsConstraint)
 DEFINE_ALLOW_RAW_POINTER(SPVectorUnsignedShort)
 DEFINE_ALLOW_RAW_POINTER(SPVectorFloat)
 DEFINE_ALLOW_RAW_POINTER(SPVectorEventPtr)
@@ -516,7 +519,7 @@ EMSCRIPTEN_BINDINGS(spine) {
     REGISTER_SPINE_ENUM(TextureFilter);
     REGISTER_SPINE_ENUM(TextureWrap);
     REGISTER_SPINE_ENUM(AttachmentType);
-
+    REGISTER_SPINE_ENUM(Physics);
 
     REGISTER_SPINE_VECTOR(SPVectorDebugShape, false);
 
@@ -544,7 +547,9 @@ EMSCRIPTEN_BINDINGS(spine) {
     REGISTER_SPINE_VECTOR(SPVectorIkConstraintDataPtr, false);
     REGISTER_SPINE_VECTOR(SPVectorTransformConstraintPtr, false);
     REGISTER_SPINE_VECTOR(SPVectorPathConstraintPtr, false);
-    REGISTER_SPINE_VECTOR(SPVectorTimelinePtr, true); // .set used in Animation constructor 
+    REGISTER_SPINE_VECTOR(SPVectorTimelinePtr, true); // .set used in Animation constructor
+    REGISTER_SPINE_VECTOR(SPVectorPhysicsConstraintDataPtr, false);
+    REGISTER_SPINE_VECTOR(SPVectorPhysicsConstraintPtr, false);
     REGISTER_SPINE_VECTOR(SPVectorTrackEntryPtr, false);
     REGISTER_SPINE_VECTOR(SPVectorUpdatablePtr, false);
     REGISTER_SPINE_VECTOR(SPVectorSkinEntryPtr, false);
@@ -879,6 +884,64 @@ EMSCRIPTEN_BINDINGS(spine) {
         .property("mixScaleY", &TransformConstraint::getMixScaleY)
         .property("mixShearY", &TransformConstraint::getMixShearY);
 
+    class_<PhysicsConstraintData, base<ConstraintData>>("PhysicsConstraintData")
+        .constructor<const String &>()
+        .property("bone", &PhysicsConstraintData::getBone)
+        .property("x", &PhysicsConstraintData::getX, &PhysicsConstraintData::setX)
+        .property("y", &PhysicsConstraintData::getY, &PhysicsConstraintData::setY)
+        .property("rotate", &PhysicsConstraintData::getRotate, &PhysicsConstraintData::setRotate)
+        .property("scaleX", &PhysicsConstraintData::getScaleX, &PhysicsConstraintData::setScaleX)
+        .property("shearX", &PhysicsConstraintData::getShearX, &PhysicsConstraintData::setShearX)
+        .property("limit", &PhysicsConstraintData::getLimit, &PhysicsConstraintData::setLimit)
+        .property("step", &PhysicsConstraintData::getStep, &PhysicsConstraintData::setStep)
+        .property("inertia", &PhysicsConstraintData::getInertia, &PhysicsConstraintData::setInertia)
+        .property("strength", &PhysicsConstraintData::getStrength, &PhysicsConstraintData::setStrength)
+        .property("damping", &PhysicsConstraintData::getDamping, &PhysicsConstraintData::setDamping)
+        .property("massInverse", &PhysicsConstraintData::getMassInverse, &PhysicsConstraintData::setMassInverse)
+        .property("wind", &PhysicsConstraintData::getWind, &PhysicsConstraintData::setWind)
+        .property("gravity", &PhysicsConstraintData::getGravity, &PhysicsConstraintData::setGravity)
+        .property("mix", &PhysicsConstraintData::getMix, &PhysicsConstraintData::setMix)
+        .property("inertiaGlobal", &PhysicsConstraintData::isInertiaGlobal, &PhysicsConstraintData::setInertiaGlobal)
+        .property("strengthGlobal", &PhysicsConstraintData::isStrengthGlobal, &PhysicsConstraintData::setStrengthGlobal)
+        .property("dampingGlobal", &PhysicsConstraintData::isDampingGlobal, &PhysicsConstraintData::setDampingGlobal)
+        .property("massGlobal", &PhysicsConstraintData::isMassGlobal, &PhysicsConstraintData::setMassGlobal)
+        .property("windGlobal", &PhysicsConstraintData::isWindGlobal, &PhysicsConstraintData::setWindGlobal)
+        .property("gravityGlobal", &PhysicsConstraintData::isGravityGlobal, &PhysicsConstraintData::setGravityGlobal)
+        .property("mixGlobal", &PhysicsConstraintData::isMixGlobal, &PhysicsConstraintData::setMixGlobal);
+
+    class_<PhysicsConstraint, base<Updatable>>("PhysicsConstraint")
+        .constructor<PhysicsConstraintData &, Skeleton &>()
+        .property("data", GETTER_RVAL_TO_PTR(PhysicsConstraint, getData, PhysicsConstraintData*))
+        .property("bone", &PhysicsConstraint::getBone, &PhysicsConstraint::setBone)
+        .property("inertia", &PhysicsConstraint::getInertia, &PhysicsConstraint::setInertia)
+        .property("strength", &PhysicsConstraint::getStrength, &PhysicsConstraint::setStrength)
+        .property("damping", &PhysicsConstraint::getDamping, &PhysicsConstraint::setDamping)
+        .property("massInverse", &PhysicsConstraint::getMassInverse, &PhysicsConstraint::setMassInverse)
+        .property("wind", &PhysicsConstraint::getWind, &PhysicsConstraint::setWind)
+        .property("gravity", &PhysicsConstraint::getGravity, &PhysicsConstraint::setGravity)
+        .property("mix", &PhysicsConstraint::getMix, &PhysicsConstraint::setMix)
+        .property("_reset", &PhysicsConstraint::getReset, &PhysicsConstraint::setReset)
+        .property("ux", &PhysicsConstraint::getUx, &PhysicsConstraint::setUx)
+        .property("uy", &PhysicsConstraint::getUy, &PhysicsConstraint::setUy)
+        .property("cx", &PhysicsConstraint::getCx, &PhysicsConstraint::setCx)
+        .property("cy", &PhysicsConstraint::getCy, &PhysicsConstraint::setCy)
+        .property("tx", &PhysicsConstraint::getTx, &PhysicsConstraint::setTx)
+        .property("ty", &PhysicsConstraint::getTy, &PhysicsConstraint::setTy)
+        .property("xOffset", &PhysicsConstraint::getXOffset, &PhysicsConstraint::setXOffset)
+        .property("xVelocity", &PhysicsConstraint::getXVelocity, &PhysicsConstraint::setXVelocity)
+        .property("yOffset", &PhysicsConstraint::getYOffset, &PhysicsConstraint::setYOffset)
+        .property("yVelocity", &PhysicsConstraint::getYVelocity, &PhysicsConstraint::setYVelocity)
+        .property("rotateOffset", &PhysicsConstraint::getRotateOffset, &PhysicsConstraint::setRotateOffset)
+        .property("rotateVelocity", &PhysicsConstraint::getRotateVelocity, &PhysicsConstraint::setRotateVelocity)
+        .property("scaleOffset", &PhysicsConstraint::getScaleOffset, &PhysicsConstraint::setScaleOffset)
+        .property("scaleVelocity", &PhysicsConstraint::getScaleVelocity, &PhysicsConstraint::setScaleVelocity)
+        .property("remaining", &PhysicsConstraint::getRemaining, &PhysicsConstraint::setRemaining)
+        .property("lastTime", &PhysicsConstraint::getLastTime, &PhysicsConstraint::setLastTime)
+        .function("reset", &PhysicsConstraint::reset)
+        .function("setToSetupPose", &PhysicsConstraint::setToSetupPose)
+        .function("translate", &PhysicsConstraint::translate)
+        .function("rotate", &PhysicsConstraint::rotate);
+
     class_<Bone, base<Updatable>>("Bone")
         .constructor<BoneData &, Skeleton &, Bone *>()
         .property("data", GETTER_RVAL_TO_PTR(Bone, getData, BoneData*))
@@ -1058,7 +1121,7 @@ EMSCRIPTEN_BINDINGS(spine) {
         .function("findAnimation", &SkeletonData::findAnimation, allow_raw_pointers())
         .function("findIkConstraint", &SkeletonData::findIkConstraint, allow_raw_pointers())
         .function("findTransformConstraint", &SkeletonData::findTransformConstraint, allow_raw_pointers())
-        .function("findPhysicsConstraint", &SkeletonData::findPathConstraint, allow_raw_pointers())
+        .function("findPhysicsConstraint", &SkeletonData::findPhysicsConstraint, allow_raw_pointers())
         .function("findPathConstraint", &SkeletonData::findPathConstraint, allow_raw_pointers());
 
     class_<Animation>("Animation")
@@ -1295,6 +1358,8 @@ EMSCRIPTEN_BINDINGS(spine) {
             return &obj.getTransformConstraints(); }), allow_raw_pointer<SPVectorTransformConstraintPtr>())
         .function("getPathConstraints", optional_override([](Skeleton &obj){
             return &obj.getPathConstraints(); }), allow_raw_pointer<SPVectorPathConstraintPtr>())
+        .function("getPhysicsConstraints", optional_override([](Skeleton &obj){
+            return &obj.getPhysicsConstraints(); }), allow_raw_pointer<SPVectorPhysicsConstraintPtr>())
         .function("getUpdateCacheList", optional_override([](Skeleton &obj){
             return &obj.getUpdateCacheList(); }), allow_raw_pointer<SPVectorUpdatablePtr>())
         .property("skin", &Skeleton::_skin)
@@ -1322,6 +1387,7 @@ EMSCRIPTEN_BINDINGS(spine) {
         .function("findIkConstraint", &Skeleton::findIkConstraint, allow_raw_pointers())
         .function("findTransformConstraint", &Skeleton::findTransformConstraint, allow_raw_pointers())
         .function("findPathConstraint", &Skeleton::findPathConstraint, allow_raw_pointers())
+        .function("findPhysicsConstraint", &Skeleton::findPhysicsConstraint, allow_raw_pointers())
         //.function("getBounds", optional_override([](Skeleton &obj, &outX, ) {}), allow_raw_pointers())
         .function("update", &Skeleton::update);
 

--- a/native/external-config.json
+++ b/native/external-config.json
@@ -3,6 +3,6 @@
         "type": "github",
         "owner": "cocos",
         "name": "cocos-engine-external",
-        "checkout": "v4.0.0-3"
+        "checkout": "v4.0.0-4"
     }
 }


### PR DESCRIPTION
实际项目中需要通过代码动态控制 spine 物理约束参数(如风力、重力、惯性等),
用于角色头发飘动、衣物摆动等效果的实时调整

具体使用场景例如触摸时给`wind`,`gravity`增加offset
然后再复原, 就可以达成与spine物理系统互动

原有绑定不完整,调用 getPhysicsConstraints() 会报 UnboundTypeError,
此 PR 补完缺失的绑定

### Changelog
- Add SPVectorPhysicsConstraintPtr using
- Add DEFINE_ALLOW_RAW_POINTER for
PhysicsConstraintData/PhysicsConstraint
- Add REGISTER_SPINE_ENUM(Physics)
- Add REGISTER_SPINE_VECTOR for physics types
- Add PhysicsConstraintData/PhysicsConstraint class bindings
- Add Skeleton.getPhysicsConstraints/findPhysicsConstraint
- Fix SkeletonData.findPhysicsConstraint pointing to wrong function
- Sync spine-core.d.ts type definitions

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
