### PR TITLE
1.适配DirectorEvent.RESET后调用physicscontactmanager.clear.

### DIFF
--- a/cocos/physics-2d/box2d-jsb/physics-world.ts
+++ b/cocos/physics-2d/box2d-jsb/physics-world.ts
@@ -479,4 +479,7 @@ export class b2PhysicsWorld implements IPhysicsWorld {
         c.emit(Contact2DType.POST_SOLVE);
         c._setImpulse(null);
     }
+    clearContacts (): void {
+        PhysicsContactManager.clear();
+    }
 }

--- a/cocos/physics-2d/box2d-wasm/physics-contact-manager.ts
+++ b/cocos/physics-2d/box2d-wasm/physics-contact-manager.ts
@@ -1,0 +1,34 @@
+/*
+ Copyright (c) 2024 Xiamen Yaji Software Co., Ltd.
+ https://www.cocos.com/
+*/
+import { B2ObjectType, getTSObjectFromWASMObjectPtr } from './instantiated';
+import { PhysicsContact } from './physics-contact';
+
+const pools: PhysicsContact[] = [];
+
+export class PhysicsContactManager {
+    static get (b2contact: number): PhysicsContact {
+        let c = pools.pop();
+        if (!c) {
+            c = new PhysicsContact();
+        }
+        c.init(b2contact);
+        return c;
+    }
+    static find (b2contact: number): PhysicsContact | null {
+        return getTSObjectFromWASMObjectPtr<PhysicsContact>(B2ObjectType.Contact, b2contact);
+    }
+
+    static put (b2contact: number): void {
+        const c = getTSObjectFromWASMObjectPtr<PhysicsContact>(B2ObjectType.Contact, b2contact);
+        if (!c) return;
+
+        pools.push(c);
+        c.reset();
+    }
+
+    static clear (): void {
+        pools.length = 0;
+    }
+}

--- a/cocos/physics-2d/box2d-wasm/physics-contact.ts
+++ b/cocos/physics-2d/box2d-wasm/physics-contact.ts
@@ -29,7 +29,7 @@ import { Collider2D, Contact2DType, PhysicsSystem2D } from '../framework';
 import { B2Shape2D } from './shapes/shape-2d';
 import { IPhysics2DContact, IPhysics2DImpulse, IPhysics2DManifoldPoint, IPhysics2DWorldManifold } from '../spec/i-physics-contact';
 
-const pools: PhysicsContact[] = [];
+/* pools moved to PhysicsContactManager */
 
 // temp world manifold
 const pointCache = [new Vec2(), new Vec2()];
@@ -62,24 +62,7 @@ const impulse: IPhysics2DImpulse = {
 
 /** @mangle */
 export class PhysicsContact implements IPhysics2DContact {
-    static get (b2contact: number): PhysicsContact {
-        let c = pools.pop();
-
-        if (!c) {
-            c = new PhysicsContact();
-        }
-
-        c.init(b2contact);
-        return c;
-    }
-
-    static put (b2contact: number): void {
-        const c = getTSObjectFromWASMObjectPtr<PhysicsContact>(B2ObjectType.Contact, b2contact);
-        if (!c) return;
-
-        pools.push(c);
-        c.reset();
-    }
+    /* static get/put/clear moved to PhysicsContactManager */
 
     colliderA: Collider2D | null = null;
     colliderB: Collider2D | null = null;

--- a/cocos/physics-2d/box2d-wasm/physics-world.ts
+++ b/cocos/physics-2d/box2d-wasm/physics-world.ts
@@ -35,7 +35,7 @@ import { B2RigidBody2D } from './rigid-body';
 import { PhysicsContactListener } from './platform/physics-contact-listener';
 import { PhysicsAABBQueryCallback } from './platform/physics-aabb-query-callback';
 import { PhysicsRayCastCallback } from './platform/physics-ray-cast-callback';
-import { PhysicsContact } from './physics-contact';
+import { PhysicsContactManager } from './physics-contact-manager';
 import { Contact2DType, Collider2D, RaycastResult2D } from '../framework';
 import { B2Shape2D } from './shapes/shape-2d';
 import { PhysicsDebugDraw } from './platform/physics-debug-draw';
@@ -437,22 +437,22 @@ export class B2PhysicsWorld implements IPhysicsWorld {
     }
 
     _onBeginContact (b2contact: number): void {
-        const c = PhysicsContact.get(b2contact);
+        const c = PhysicsContactManager.get(b2contact);
         c.emit(Contact2DType.BEGIN_CONTACT);
     }
 
     _onEndContact (b2contact: number): void {
-        const c = getTSObjectFromWASMObjectPtr<PhysicsContact>(B2ObjectType.Contact, b2contact);
+        const c = PhysicsContactManager.find(b2contact);
         if (!c) {
             return;
         }
         c.emit(Contact2DType.END_CONTACT);
 
-        PhysicsContact.put(b2contact);
+        PhysicsContactManager.put(b2contact);
     }
 
     _onPreSolve (b2contact: number): void {
-        const c = getTSObjectFromWASMObjectPtr<PhysicsContact>(B2ObjectType.Contact, b2contact);
+        const c = PhysicsContactManager.find(b2contact);
         if (!c) {
             return;
         }
@@ -461,7 +461,7 @@ export class B2PhysicsWorld implements IPhysicsWorld {
     }
 
     _onPostSolve (b2contact: number, impulse: number): void {
-        const c = getTSObjectFromWASMObjectPtr<PhysicsContact>(B2ObjectType.Contact, b2contact);
+        const c = PhysicsContactManager.find(b2contact);
         if (!c) {
             return;
         }
@@ -470,5 +470,9 @@ export class B2PhysicsWorld implements IPhysicsWorld {
         c._setImpulse(impulse);
         c.emit(Contact2DType.POST_SOLVE);
         c._setImpulse(0);
+    }
+
+    clearContacts (): void {
+        PhysicsContactManager.clear();
     }
 }

--- a/cocos/physics-2d/box2d/physics-contact-manager.ts
+++ b/cocos/physics-2d/box2d/physics-contact-manager.ts
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2022-2023 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2024 Xiamen Yaji Software Co., Ltd.
 
  https://www.cocos.com/
 
@@ -21,22 +21,36 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
 */
+import { PhysicsContact, b2ContactExtends } from './physics-contact';
 
-import { IVec2Like, Rect, Vec2 } from '../../core';
-import { ERaycast2DType, RaycastResult2D, Collider2D } from '../framework';
+const contactMap = new Map<b2ContactExtends, PhysicsContact>();
+const pools: PhysicsContact[] = [];
 
-export interface IPhysicsWorld {
-    readonly impl: any;
-    debugDrawFlags: number;
-    setGravity: (v: IVec2Like) => void;
-    setAllowSleep: (v: boolean) => void;
-    // setDefaultMaterial: (v: PhysicMaterial) => void;
-    step (deltaTime: number, velocityIterations?: number, positionIterations?: number): void;
-    syncPhysicsToScene (): void;
-    syncSceneToPhysics (): void;
-    raycast (p1: IVec2Like, p2: IVec2Like, type: ERaycast2DType, mask: number): RaycastResult2D[];
-    testPoint (p: Vec2): readonly Collider2D[];
-    testAABB (rect: Rect): readonly Collider2D[];
-    drawDebug (): void;
-    clearContacts (): void;
+export class PhysicsContactManager {
+    static get (b2contact: b2ContactExtends): PhysicsContact {
+        let c = pools.pop();
+        if (!c) {
+            c = new PhysicsContact();
+        }
+        c.init(b2contact);
+        contactMap.set(b2contact, c);
+        return c;
+    }
+
+    static find (b2contact: b2ContactExtends): PhysicsContact | null {
+        return contactMap.get(b2contact) ?? null;
+    }
+
+    static put (b2contact: b2ContactExtends): void {
+        const c = contactMap.get(b2contact);
+        if (!c) return;
+        pools.push(c);
+        c.reset();
+        contactMap.delete(b2contact);
+    }
+
+    static clear (): void {
+        contactMap.clear();
+        pools.length = 0;
+    }
 }

--- a/cocos/physics-2d/box2d/physics-contact.ts
+++ b/cocos/physics-2d/box2d/physics-contact.ts
@@ -33,8 +33,6 @@ export type b2ContactExtends = b2.Contact & {
     m_userData: any;
 }
 
-const pools: PhysicsContact[] = [];
-
 // temp world manifold
 const pointCache = [new Vec2(), new Vec2()];
 
@@ -68,25 +66,6 @@ const impulse: IPhysics2DImpulse = {
 
 /** @mangle */
 export class PhysicsContact implements IPhysics2DContact {
-    static get (b2contact: b2ContactExtends): PhysicsContact {
-        let c = pools.pop();
-
-        if (!c) {
-            c = new PhysicsContact();
-        }
-
-        c.init(b2contact);
-        return c;
-    }
-
-    static put (b2contact: b2ContactExtends): void {
-        const c: PhysicsContact = b2contact.m_userData as PhysicsContact;
-        if (!c) return;
-
-        pools.push(c);
-        c.reset();
-    }
-
     colliderA: Collider2D | null = null;
     colliderB: Collider2D | null = null;
 
@@ -111,7 +90,6 @@ export class PhysicsContact implements IPhysics2DContact {
         this._inverted = false;
 
         this._b2contact = b2contact;
-        b2contact.m_userData = this;
     }
 
     reset (): void {
@@ -124,7 +102,6 @@ export class PhysicsContact implements IPhysics2DContact {
         this.disabled = false;
         this._impulse = null;
 
-        this._b2contact!.m_userData = null;
         this._b2contact = null;
     }
 

--- a/cocos/physics-2d/box2d/physics-world.ts
+++ b/cocos/physics-2d/box2d/physics-world.ts
@@ -39,6 +39,7 @@ import { PhysicsDebugDraw } from './platform/physics-debug-draw';
 import { Node, find, Layers } from '../../scene-graph';
 import { director } from '../../game';
 import type { Graphics } from '../../2d/components/graphics';
+import { PhysicsContactManager } from './physics-contact-manager';
 
 const tempVec3 = new Vec3();
 const tempVec2_1 = new Vec2();
@@ -414,22 +415,22 @@ export class b2PhysicsWorld implements IPhysicsWorld {
     }
 
     _onBeginContact (b2contact: b2ContactExtends): void {
-        const c = PhysicsContact.get(b2contact);
+        const c = PhysicsContactManager.get(b2contact);
         c.emit(Contact2DType.BEGIN_CONTACT);
     }
 
     _onEndContact (b2contact: b2ContactExtends): void {
-        const c = b2contact.m_userData as PhysicsContact;
+        const c = PhysicsContactManager.find(b2contact);
         if (!c) {
             return;
         }
         c.emit(Contact2DType.END_CONTACT);
 
-        PhysicsContact.put(b2contact);
+        PhysicsContactManager.put(b2contact);
     }
 
     _onPreSolve (b2contact: b2ContactExtends): void {
-        const c = b2contact.m_userData as PhysicsContact;
+        const c = PhysicsContactManager.find(b2contact);
         if (!c) {
             return;
         }
@@ -438,7 +439,7 @@ export class b2PhysicsWorld implements IPhysicsWorld {
     }
 
     _onPostSolve (b2contact: b2ContactExtends, impulse: b2.ContactImpulse): void {
-        const c: PhysicsContact = b2contact.m_userData as PhysicsContact;
+        const c = PhysicsContactManager.find(b2contact);
         if (!c) {
             return;
         }
@@ -447,5 +448,8 @@ export class b2PhysicsWorld implements IPhysicsWorld {
         c._setImpulse(impulse);
         c.emit(Contact2DType.POST_SOLVE);
         c._setImpulse(null);
+    }
+    clearContacts (): void {
+        PhysicsContactManager.clear();
     }
 }

--- a/cocos/physics-2d/builtin/builtin-world.ts
+++ b/cocos/physics-2d/builtin/builtin-world.ts
@@ -285,4 +285,6 @@ export class BuiltinPhysicsWorld implements IPhysicsWorld {
     raycast (p1: IVec2Like, p2: IVec2Like, type: ERaycast2DType): RaycastResult2D[] {
         return [];
     }
+    clearContacts (): void {
+    }
 }

--- a/cocos/physics-2d/framework/physics-selector.ts
+++ b/cocos/physics-2d/framework/physics-selector.ts
@@ -165,6 +165,7 @@ const ENTIRE_WORLD: IPhysicsWorld = {
     testPoint: FUNC,
     testAABB: FUNC,
     drawDebug: FUNC,
+    clearContacts: FUNC,
 };
 
 export function checkPhysicsModule (obj: any): boolean {

--- a/cocos/physics-2d/framework/physics-system.ts
+++ b/cocos/physics-2d/framework/physics-system.ts
@@ -381,8 +381,12 @@ export class PhysicsSystem2D extends Eventify(System) {
     static constructAndRegister (): void {
         director.registerSystem(PhysicsSystem2D.ID, PhysicsSystem2D.instance, SystemPriority.LOW);
     }
+    clearContacts (): void {
+        this.physicsWorld.clearContacts();
+    }
 }
 
 if (!BUILD || !LOAD_BOX2D_MANUALLY) {
     director.once(DirectorEvent.INIT, (): void => { PhysicsSystem2D.constructAndRegister(); });
+    director.once(DirectorEvent.RESET, (): void => { PhysicsSystem2D.instance.clearContacts(); });
 }


### PR DESCRIPTION
1.适配DirectorEvent.RESET后调用physicscontactmanager.clear. 2.根据1来调整，box2d, box2d-jsb, box2d-wam

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
