### PR TITLE
fix: GCC 16 compatibility and EventBus patches

### DIFF
--- a/.github/workflows/native-unit-test.yml
+++ b/.github/workflows/native-unit-test.yml
@@ -51,7 +51,7 @@ jobs:
           cd tests/unit-test/build
           # cmake --build tests/unit-test/build --config Release -j${cpus}
           ls -l
-          xcodebuild -project CocosTest.xcodeproj -scheme "CocosTest" -jobs ${cpus} -arch arm64 -configuration Release build CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+          xcodebuild -project CocosTest.xcodeproj -scheme "CocosNative" -jobs ${cpus} -arch arm64 -configuration Release build CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
           ./src/Release/CocosTest
 
       #### TODO(PatriceJiang): model split

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.10)
+project(CocosNative)
 if(NOT USE_XR AND NOT USE_AR_MODULE)
     include(${CMAKE_CURRENT_LIST_DIR}/cmake/predefine.cmake)
 endif()

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.10)
-project(CocosNative)
 if(NOT USE_XR AND NOT USE_AR_MODULE)
     include(${CMAKE_CURRENT_LIST_DIR}/cmake/predefine.cmake)
 endif()

--- a/native/cocos/plugins/bus/EventBus.cpp
+++ b/native/cocos/plugins/bus/EventBus.cpp
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <unordered_map>
 #include "base/Macros.h"
+#include <algorithm>
 
 namespace cc {
 namespace plugin {

--- a/native/cocos/plugins/bus/EventBus.h
+++ b/native/cocos/plugins/bus/EventBus.h
@@ -30,10 +30,9 @@
 #include <tuple>
 #include <typeinfo>
 #include <utility>
-
 #include <unordered_map>
 #include <vector>
-
+#include <cstdint>
 #include "plugins/bus/BusTypes.h"
 
 namespace cc {


### PR DESCRIPTION
Re: #

### Changelog

* Fixed GCC 16.1.1 compatibility issues in EventBus and updated build configuration
Fixed compilation errors with GCC 16.1.1 by patching EventBus and updating build configurations for modern Linux toolchains.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [x] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [x ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
