### PR TITLE
fix(physics-2d): avoid debug draw crash when toggling flags

### DIFF
--- a/cocos/physics-2d/box2d-jsb/physics-world.ts
+++ b/cocos/physics-2d/box2d-jsb/physics-world.ts
@@ -141,7 +141,7 @@ export class b2PhysicsWorld implements IPhysicsWorld {
 
         if (!v) {
             if (this._debugGraphics) {
-                this._debugGraphics.node.parent = null;
+                this._debugGraphics.clear();
             }
         }
 

--- a/cocos/physics-2d/box2d-wasm/physics-world.ts
+++ b/cocos/physics-2d/box2d-wasm/physics-world.ts
@@ -114,7 +114,7 @@ export class B2PhysicsWorld implements IPhysicsWorld {
 
         if (!v) {
             if (this._debugGraphics) {
-                this._debugGraphics.node.parent = null;
+                this._debugGraphics.clear();
             }
         }
 

--- a/cocos/physics-2d/box2d/physics-world.ts
+++ b/cocos/physics-2d/box2d/physics-world.ts
@@ -100,7 +100,7 @@ export class b2PhysicsWorld implements IPhysicsWorld {
 
         if (!v) {
             if (this._debugGraphics) {
-                this._debugGraphics.node.parent = null;
+                this._debugGraphics.clear();
             }
         }
 

--- a/tests/physics2d/debug-draw.ts
+++ b/tests/physics2d/debug-draw.ts
@@ -1,0 +1,37 @@
+import * as physics2d from "../../exports/physics-2d-framework";
+
+/**
+ * 验证 Box2D 后端关闭调试绘制时保留调试节点，避免再次开启时父节点为空。
+ */
+export default function DebugDrawTest (): void {
+    if (physics2d.selector.id === 'builtin') {
+        return;
+    }
+
+    const parent = {};
+    const clear = jest.fn();
+    const debugGraphics = {
+        clear,
+        node: {
+            parent,
+        },
+    };
+    const physicsWorld = physics2d.PhysicsSystem2D.instance.physicsWorld as unknown as {
+        _debugGraphics: typeof debugGraphics | null;
+    };
+
+    physicsWorld._debugGraphics = debugGraphics;
+
+    try {
+        physics2d.PhysicsSystem2D.instance.debugDrawFlags = physics2d.EPhysics2DDrawFlags.Shape;
+        physics2d.PhysicsSystem2D.instance.debugDrawFlags = physics2d.EPhysics2DDrawFlags.None;
+        expect(clear).toHaveBeenCalledTimes(1);
+        expect(debugGraphics.node.parent).toBe(parent);
+
+        physics2d.PhysicsSystem2D.instance.debugDrawFlags = physics2d.EPhysics2DDrawFlags.Shape;
+        expect(debugGraphics.node.parent).toBe(parent);
+    } finally {
+        physics2d.PhysicsSystem2D.instance.debugDrawFlags = physics2d.EPhysics2DDrawFlags.None;
+        physicsWorld._debugGraphics = null;
+    }
+}

--- a/tests/physics2d/physics2d.test.ts
+++ b/tests/physics2d/physics2d.test.ts
@@ -12,6 +12,7 @@ import RigidBodyTest from "./rigid-body";
 import ColliderTest from "./collider"; 
 import SceneQueryTest from "./scene-query";
 import EventTest from "./events";
+import DebugDrawTest from "./debug-draw";
 
 game.emit(Game.EVENT_PRE_SUBSYSTEM_INIT);
 physics2d.PhysicsSystem2D.constructAndRegister();
@@ -49,6 +50,9 @@ for (const id in physics2d.selector.backend) {
 
         //test events
         EventTest(temp0);
+
+        //test debug draw
+        DebugDrawTest();
 
         // destroy test scene
         temp0.destroy();


### PR DESCRIPTION
Re: https://forum.cocos.org/t/topic/167059/6

### Changelog

* Fixed a crash caused by toggling 2D Box2D debug draw flags from Shape to None and back to Shape.
* Clear cached debug graphics instead of detaching the debug draw node when `debugDrawFlags` is set to `None`.
* Added a regression test for toggling Box2D debug draw flags.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.