### PR TITLE
feat(2d): support rounded rect mask radius

### DIFF
--- a/cocos/2d/components/mask.ts
+++ b/cocos/2d/components/mask.ts
@@ -64,10 +64,10 @@ function _calculateCircle (center: Vec3, radius: Vec3, segments: number): Vec3[]
  */
 export enum MaskType {
     /**
-     * @en Rect mask.
+     * @en Rect mask, supports rounded corners by setting radius.
      *
      * @zh
-     * 使用矩形作为遮罩。
+     * 使用矩形作为遮罩，可通过 radius 设置圆角。
      */
     GRAPHICS_RECT = 0,
 
@@ -217,6 +217,32 @@ export class Mask extends Component {
 
     /**
      * @en
+     * The radius for rounded corners of rect mask.
+     *
+     * @zh
+     * 矩形遮罩的圆角半径。
+     */
+    @visible(function (this: Mask) {
+        return this.type === MaskType.GRAPHICS_RECT;
+    })
+    @tooltip('i18n:mask.radius')
+    @range([0, Number.POSITIVE_INFINITY])
+    get radius (): number {
+        return this._radius;
+    }
+
+    set radius (value) {
+        const radius = clamp(value, 0, Number.POSITIVE_INFINITY);
+        if (this._radius === radius) {
+            return;
+        }
+
+        this._radius = radius;
+        this._updateGraphics();
+    }
+
+    /**
+     * @en
      * The mask image.
      *
      * @zh
@@ -290,6 +316,9 @@ export class Mask extends Component {
     protected _segments = 64;
 
     @serializable
+    protected _radius = 0;
+
+    @serializable
     protected _alphaThreshold = 0.1;
 
     protected _sprite: Sprite | null = null;
@@ -350,7 +379,25 @@ export class Mask extends Component {
         testPt.y += ap.y * h;
 
         let result = false;
-        if (this.type === MaskType.GRAPHICS_RECT || this.type === MaskType.GRAPHICS_STENCIL || this.type === MaskType.SPRITE_STENCIL) {
+        if (this.type === MaskType.GRAPHICS_RECT) {
+            result = testPt.x >= 0 && testPt.y >= 0 && testPt.x <= w && testPt.y <= h;
+            const radius = Math.min(this._radius, w / 2, h / 2);
+            if (result && radius > 0) {
+                let dx = 0;
+                let dy = 0;
+                if (testPt.x < radius) {
+                    dx = testPt.x - radius;
+                } else if (testPt.x > w - radius) {
+                    dx = testPt.x - (w - radius);
+                }
+                if (testPt.y < radius) {
+                    dy = testPt.y - radius;
+                } else if (testPt.y > h - radius) {
+                    dy = testPt.y - (h - radius);
+                }
+                result = dx * dx + dy * dy <= radius * radius;
+            }
+        } else if (this.type === MaskType.GRAPHICS_STENCIL || this.type === MaskType.SPRITE_STENCIL) {
             result = testPt.x >= 0 && testPt.y >= 0 && testPt.x <= w && testPt.y <= h;
         } else if (this.type === MaskType.GRAPHICS_ELLIPSE) {
             const rx = w / 2;
@@ -423,7 +470,12 @@ export class Mask extends Component {
         const x = -width * ap.x;
         const y = -height * ap.y;
         if (this._type === MaskType.GRAPHICS_RECT) {
-            graphics.rect(x, y, width, height);
+            const radius = Math.min(this._radius, width / 2, height / 2);
+            if (radius > 0) {
+                graphics.roundRect(x, y, width, height, radius);
+            } else {
+                graphics.rect(x, y, width, height);
+            }
         } else if (this._type === MaskType.GRAPHICS_ELLIPSE) {
             const center = new Vec3(x + width / 2, y + height / 2, 0);
             const radius = new Vec3(width / 2, height / 2, 0);

--- a/editor/i18n/en/localization.js
+++ b/editor/i18n/en/localization.js
@@ -779,6 +779,7 @@ module.exports = link(mixin({
     },
     mask: {
         type: 'The mask type',
+        radius: 'The radius for rounded corners of rect mask',
         spriteFrame: 'The mask image',
         inverted: 'The Reverse mask (Not supported Canvas Mode)',
         alphaThreshold:

--- a/editor/i18n/zh/localization.js
+++ b/editor/i18n/zh/localization.js
@@ -760,6 +760,7 @@ module.exports = link(mixin({
     },
     mask: {
         type: '遮罩类型',
+        radius: '矩形遮罩的圆角半径',
         spriteFrame: '遮罩所需要的贴图',
         inverted: '反向遮罩（不支持 Canvas 模式）',
         alphaThreshold: 'Alpha 阈值，只有当模板的像素的 Alpha 大于 Alpha Threshold 时，才会绘制内容（不支持 Canvas 模式）',


### PR DESCRIPTION
- Add `Mask.radius` for `GRAPHICS_RECT` masks.
- Render rect masks with `Graphics.roundRect` when radius is greater than 0.
- Update rect mask hit testing to respect rounded corners and inverted mode.
- Add editor i18n text for the new radius property.

Re: #

### Changelog

* Added rounded corner radius support for rect masks.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [x] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
  > Adds `Mask.radius`, default value is `0`, existing rect mask behavior remains unchanged.
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.