### PR TITLE
fix(physics-2d): correct circle collider world position

### DIFF
--- a/cocos/physics-2d/box2d-jsb/shapes/circle-shape-2d.ts
+++ b/cocos/physics-2d/box2d-jsb/shapes/circle-shape-2d.ts
@@ -34,8 +34,8 @@ export class b2CircleShape extends b2Shape2D implements ICircleShape {
 
     _worldPosition = new Vec2();
     get worldPosition (): Vec2 {
-        const p = (this._shapes[0] as b2jsb.CircleShape).m_p;
-        return this._worldPosition.set(p.x * PHYSICS_2D_PTM_RATIO, p.y * PHYSICS_2D_PTM_RATIO);
+        const comp = this.collider as CircleCollider2D;
+        return Vec2.transformMat4(this._worldPosition, comp.offset, comp.node.worldMatrix);
     }
 
     _createShapes (scaleX: number, scaleY: number, relativePositionX: number, relativePositionY: number): any[] {

--- a/cocos/physics-2d/box2d-wasm/shapes/circle-shape-2d.ts
+++ b/cocos/physics-2d/box2d-wasm/shapes/circle-shape-2d.ts
@@ -37,8 +37,8 @@ export class B2CircleShape extends B2Shape2D implements ICircleShape {
 
     _worldPosition = new Vec2();
     get worldPosition (): Vec2 {
-        const p = B2.CircleShapeGetPosition(this._shapes[0]) as B2.Vec2;
-        return this._worldPosition.set(p.x * PHYSICS_2D_PTM_RATIO, p.y * PHYSICS_2D_PTM_RATIO);
+        const comp = this.collider as CircleCollider2D;
+        return Vec2.transformMat4(this._worldPosition, comp.offset, comp.node.worldMatrix);
     }
 
     _createShapes (scaleX: number, scaleY: number, relativePositionX: number, relativePositionY: number): number[] { //B2.CircleShape[]

--- a/cocos/physics-2d/box2d/shapes/circle-shape-2d.ts
+++ b/cocos/physics-2d/box2d/shapes/circle-shape-2d.ts
@@ -37,8 +37,8 @@ export class b2CircleShape extends b2Shape2D implements ICircleShape {
 
     _worldPosition = new Vec2();
     get worldPosition (): Vec2 {
-        const p = (this._shapes[0] as b2.CircleShape).m_p;
-        return this._worldPosition.set(p.x * PHYSICS_2D_PTM_RATIO, p.y * PHYSICS_2D_PTM_RATIO);
+        const comp = this.collider as CircleCollider2D;
+        return Vec2.transformMat4(this._worldPosition, comp.offset, comp.node.worldMatrix);
     }
 
     _createShapes (scaleX: number, scaleY: number, relativePositionX: number, relativePositionY: number): any[] {

--- a/tests/physics2d/collider.ts
+++ b/tests/physics2d/collider.ts
@@ -1,3 +1,5 @@
+/// <reference types="jest" />
+
 import { EPSILON, Quat, Vec2, Vec3 } from "../../cocos/core";
 import { director } from "../../cocos/game";
 import { Node } from "../../cocos/scene-graph";
@@ -36,6 +38,23 @@ export default function (parent: Node, _steps = 0) {
         collider.sensor = true;
         expect(collider.sensor).toBe(true);
     
+        parent.destroyAllChildren();
+        parent.removeAllChildren();
+    }
+
+    // circle worldPosition
+    {
+        const nodeCollider = new Node('CircleCollider2D');
+        parent.addChild(nodeCollider);
+        nodeCollider.worldPosition = new Vec3(10, 20, 0);
+
+        nodeCollider.addComponent(physics2d.RigidBody2D);
+        const collider = nodeCollider.addComponent(physics2d.CircleCollider2D) as physics2d.CircleCollider2D;
+        collider.offset = new Vec2(2, -3);
+        collider.apply();
+
+        expect(Vec2.equals(collider.worldPosition, new Vec2(12, 17))).toBe(true);
+
         parent.destroyAllChildren();
         parent.removeAllChildren();
     }


### PR DESCRIPTION
Re: https://forum.cocos.org/t/topic/174262

### Changelog

* Fixed `CircleCollider2D.worldPosition` returning the local Box2D circle center instead of the world-space center in Box2D-based physics backends.
* Added a physics2d regression test for circle collider world position with rigid body and offset.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.