### PR TITLE
Fix: crash when using RenderTexture sprite after scene switch on Android.

### DIFF
--- a/cocos/2d/components/sprite.ts
+++ b/cocos/2d/components/sprite.ts
@@ -567,7 +567,7 @@ export class Sprite extends UIRenderer {
         if (this.spriteFrame && this.spriteFrame.texture instanceof RenderTexture) {
             const rtMatName = `rt-${mat.name}`;
             let rtMat = builtinResMgr.get(rtMatName) as Material | null;
-            if (!rtMat) {
+            if (!rtMat || !rtMat.passes.length) {
                 rtMat = new Material(rtMatName);
                 rtMat.copy(mat, { defines: { SAMPLE_FROM_RT: true } });
                 builtinResMgr.addAsset(rtMatName, rtMat);

--- a/cocos/2d/framework/ui-renderer.ts
+++ b/cocos/2d/framework/ui-renderer.ts
@@ -536,7 +536,7 @@ export class UIRenderer extends Renderer {
         const mat = this._updateBuiltinMaterial();
         this.setSharedMaterial(mat, 0);
         if (this.stencilStage === Stage.ENTER_LEVEL || this.stencilStage === Stage.ENTER_LEVEL_INVERTED) {
-            this.getMaterialInstance(0)!.recompileShaders({ USE_ALPHA_TEST: true });
+            this.getMaterialInstance(0)?.recompileShaders({ USE_ALPHA_TEST: true });
         }
         this._updateBlendFunc();
     }
@@ -600,16 +600,24 @@ export class UIRenderer extends Renderer {
      */
     public _updateBlendFunc (): void {
         // todo: Not only Pass[0].target[0]
-        let target = this.getRenderMaterial(0)!.passes[0].blendState.targets[0];
+        const renderMat = this.getRenderMaterial(0);
+        if (!renderMat || !renderMat.passes[0]) {
+            return;
+        }
+        let target = renderMat.passes[0].blendState.targets[0];
         this._dstBlendFactorCache = target.blendDst;
         this._srcBlendFactorCache = target.blendSrc;
         if (this._dstBlendFactorCache !== this._dstBlendFactor || this._srcBlendFactorCache !== this._srcBlendFactor) {
-            target = this.getMaterialInstance(0)!.passes[0].blendState.targets[0];
+            const matInstance = this.getMaterialInstance(0);
+            if (!matInstance || !matInstance.passes[0]) {
+                return;
+            }
+            target = matInstance.passes[0].blendState.targets[0];
             target.blend = true;
             target.blendDstAlpha = BlendFactor.ONE_MINUS_SRC_ALPHA;
             target.blendDst = this._dstBlendFactor;
             target.blendSrc = this._srcBlendFactor;
-            const targetPass = this.getMaterialInstance(0)!.passes[0];
+            const targetPass = matInstance.passes[0];
             targetPass.blendState.setTarget(0, target);
             targetPass._updatePassHash();
             this._dstBlendFactorCache = this._dstBlendFactor;


### PR DESCRIPTION
Re: #
https://forum.cocos.org/t/topic/172523

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
