### PR TITLE
chore: downgrade verbose startup logs to debug

### DIFF
--- a/cocos/3d/misc/mesh-codec.ts
+++ b/cocos/3d/misc/mesh-codec.ts
@@ -24,7 +24,7 @@
 import { CULL_MESHOPT, NATIVE_CODE_BUNDLE_MODE } from 'internal:constants';
 import { ensureWasmModuleReady, instantiateWasm } from 'pal/wasm';
 
-import { sys, logID, error } from '../../core';
+import { sys, error, debugID } from '../../core';
 
 import { game } from '../../game';
 import { NativeCodeBundleMode } from '../../misc/webassembly-support';
@@ -53,7 +53,7 @@ function initDecoderASM (asm_factory: any): Promise<void> {
         MeshoptDecoder.decodeGltfBuffer = asm_factory.decodeGltfBuffer;
         MeshoptDecoder.useWorkers = asm_factory.useWorkers;
         MeshoptDecoder.decodeGltfBufferAsync = asm_factory.decodeGltfBufferAsync;
-        logID(14202);
+        debugID(14202);
     });
 }
 
@@ -70,7 +70,7 @@ function initDecoderWASM (wasm_factory: any, wasm_url: string): Promise<void> {
         MeshoptDecoder.decodeGltfBuffer = wasm_factory.decodeGltfBuffer;
         MeshoptDecoder.useWorkers = wasm_factory.useWorkers;
         MeshoptDecoder.decodeGltfBufferAsync = wasm_factory.decodeGltfBufferAsync;
-        logID(14203);
+        debugID(14203);
     });
 }
 

--- a/cocos/physics-2d/box2d-wasm/instantiated.ts
+++ b/cocos/physics-2d/box2d-wasm/instantiated.ts
@@ -26,7 +26,7 @@ import { instantiateWasm, ensureWasmModuleReady } from 'pal/wasm';
 import { BUILD, LOAD_BOX2D_MANUALLY, NATIVE_CODE_BUNDLE_MODE } from 'internal:constants';
 
 import { game } from '../../game';
-import { error, sys, IVec2Like, log } from '../../core';
+import { error, sys, IVec2Like, log, debug } from '../../core';
 import { NativeCodeBundleMode } from '../../misc/webassembly-support';
 
 // eslint-disable-next-line import/no-mutable-exports
@@ -148,7 +148,7 @@ function initWasm (wasmFactory, wasmUrl: string): Promise<void> {
                 }).catch((err) => reject(errorMessage(err)));
             },
         }).then((Instance: any) => {
-            log('[box2d]:box2d wasm lib loaded.');
+            debug('[box2d]:box2d wasm lib loaded.');
             B2 = Instance;
         }).then(resolve).catch((err: any) => reject(errorMessage(err)));
     });
@@ -158,7 +158,7 @@ function initAsm (asmFactory): Promise<void> {
     return new Promise<void>((resolve, reject) => {
         const errorMessage = (err: any): string => `[box2d]: box2d asm lib load failed: ${err}`;
         asmFactory().then((instance: any) => {
-            log('[box2d]:box2d asm lib loaded.');
+            debug('[box2d]:box2d asm lib loaded.');
             B2 = instance;
         }).then(resolve).catch((err: any) => reject(errorMessage(err)));
     });

--- a/cocos/physics-2d/framework/physics-selector.ts
+++ b/cocos/physics-2d/framework/physics-selector.ts
@@ -27,7 +27,7 @@ import { EDITOR, DEBUG, TEST, EDITOR_NOT_IN_PREVIEW } from 'internal:constants';
 import { IRigidBody2D } from '../spec/i-rigid-body';
 import { IBoxShape, ICircleShape, IPolygonShape, IBaseShape } from '../spec/i-physics-shape';
 import { IPhysicsWorld } from '../spec/i-physics-world';
-import { errorID, log } from '../../core';
+import { debug, errorID, log } from '../../core';
 import { ECollider2DType, EJoint2DType  } from './physics-types';
 import { IJoint2D, IDistanceJoint, ISpringJoint, IFixedJoint, IMouseJoint,
     IRelativeJoint, ISliderJoint, IWheelJoint, IHingeJoint } from '../spec/i-physics-joint';
@@ -110,7 +110,7 @@ export interface IPhysicsSelector {
 }
 
 function register (id: IPhysicsEngineId, wrapper: IPhysicsWrapperObject): void {
-    if (!EDITOR && !TEST) log(`[PHYSICS2D]: register ${id}.`);
+    if (!EDITOR && !TEST) debug(`[PHYSICS2D]: register ${id}.`);
     selector.backend[id] = wrapper;
     if (!selector.physicsWorld || selector.id === id) {
         const mutableSelector = selector as Mutable<IPhysicsSelector>;
@@ -124,12 +124,12 @@ function switchTo (id: IPhysicsEngineId): void {
     const mutableSelector = selector as Mutable<IPhysicsSelector>;
     if (selector.physicsWorld && id !== selector.id && selector.backend[id] != null) {
         //selector.physicsWorld.destroy();//todo
-        if (!TEST) log(`[PHYSICS2D]: switch from ${selector.id} to ${id}.`);
+        if (!TEST) debug(`[PHYSICS2D]: switch from ${selector.id} to ${id}.`);
         mutableSelector.id = id;
         mutableSelector.wrapper = selector.backend[id];
         mutableSelector.physicsWorld = createPhysicsWorld();
     } else {
-        if (!EDITOR && !TEST) log(`[PHYSICS2D]: using ${mutableSelector.id}.`);
+        if (!EDITOR && !TEST) debug(`[PHYSICS2D]: using ${mutableSelector.id}.`);
         mutableSelector.physicsWorld = createPhysicsWorld();
     }
 }

--- a/cocos/physics/bullet/instantiated.ts
+++ b/cocos/physics/bullet/instantiated.ts
@@ -25,7 +25,7 @@
 import { ensureWasmModuleReady, instantiateWasm } from 'pal/wasm';
 import { BUILD, LOAD_BULLET_MANUALLY, NATIVE_CODE_BUNDLE_MODE } from 'internal:constants';
 import { game } from '../../game';
-import { error, log, sys } from '../../core';
+import { debug, error, sys } from '../../core';
 import { NativeCodeBundleMode } from '../../misc/webassembly-support';
 import type { BulletCache } from './bullet-cache';
 
@@ -106,7 +106,7 @@ function initWASM (wasmFactory, wasmUrl: string): Promise<void> {
                 }).catch((err) => reject(errorMessage(err)));
             },
         }).then((instance: any) => {
-            log('[bullet]:bullet wasm lib loaded.');
+            debug('[bullet]:bullet wasm lib loaded.');
             bt = instance as Bullet.instance;
             globalThis.Bullet = bt as any;
         }).then(resolve).catch((err: any) => reject(errorMessage(err)));
@@ -117,7 +117,7 @@ function initASM (asmFactory): Promise<void> {
     if (asmFactory != null) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return asmFactory().then((instance: any) => {
-            log('[bullet]:bullet asm lib loaded.');
+            debug('[bullet]:bullet asm lib loaded.');
             bt = instance as Bullet.instance;
         });
     } else {

--- a/cocos/physics/framework/physics-selector.ts
+++ b/cocos/physics/framework/physics-selector.ts
@@ -35,7 +35,7 @@ import {
 import { IPhysicsWorld } from '../spec/i-physics-world';
 import { IRigidBody } from '../spec/i-rigid-body';
 import { IBoxCharacterController, ICapsuleCharacterController } from '../spec/i-character-controller';
-import { errorID, IVec3Like, warn, cclegacy, log } from '../../core';
+import { errorID, IVec3Like, warn, cclegacy, debug } from '../../core';
 import { EColliderType, EConstraintType, ECharacterControllerType } from './physics-enum';
 import { PhysicsMaterial } from '.';
 
@@ -125,7 +125,7 @@ function updateLegacyMacro (id: string): void {
 }
 
 function register (id: IPhysicsEngineId, wrapper: IPhysicsWrapperObject): void {
-    if (!EDITOR && !TEST) log(`[PHYSICS]: register ${id}.`);
+    if (!EDITOR && !TEST) debug(`[PHYSICS]: register ${id}.`);
     selector.backend[id] = wrapper;
     if (!selector.physicsWorld || selector.id === id) {
         updateLegacyMacro(id);
@@ -147,13 +147,13 @@ function switchTo (id: IPhysicsEngineId): void {
     const mutableSelector = selector as Mutable<IPhysicsSelector>;
     if (selector.physicsWorld && id !== selector.id && selector.backend[id] != null) {
         selector.physicsWorld.destroy();
-        if (!TEST) log(`[PHYSICS]: switch from ${selector.id} to ${id}.`);
+        if (!TEST) debug(`[PHYSICS]: switch from ${selector.id} to ${id}.`);
         updateLegacyMacro(id);
         mutableSelector.id = id;
         mutableSelector.wrapper = selector.backend[id];
         mutableSelector.physicsWorld = createPhysicsWorld();
     } else {
-        if (!EDITOR && !TEST) log(`[PHYSICS]: using ${id}.`);
+        if (!EDITOR && !TEST) debug(`[PHYSICS]: using ${id}.`);
         mutableSelector.physicsWorld = createPhysicsWorld();
     }
     if (worldInitData) {
@@ -185,7 +185,7 @@ export function constructDefaultWorld (data: IWorldInitData): void {
     if (!worldInitData) worldInitData = data;
     if (!selector.runInEditor) return;
     if (!selector.physicsWorld) {
-        if (!TEST) log(`[PHYSICS]: using ${selector.id}.`);
+        if (!TEST) debug(`[PHYSICS]: using ${selector.id}.`);
         const mutableSelector = selector as Mutable<IPhysicsSelector>;
         const world = mutableSelector.physicsWorld = createPhysicsWorld();
         world.setGravity(worldInitData.gravity);

--- a/cocos/root.jsb.ts
+++ b/cocos/root.jsb.ts
@@ -25,7 +25,7 @@
 import { cclegacy } from './core/global-exports';
 import { DataPoolManager } from './3d/skeletal-animation/data-pool-manager';
 import { Device, deviceManager } from './gfx';
-import { settings, Settings, warnID, Pool, macro, log } from './core';
+import { settings, Settings, warnID, Pool, macro, log, debug } from './core';
 import { PipelineEventProcessor } from './rendering/pipeline-event';
 import type { Root as JsbRoot } from './root';
 
@@ -242,7 +242,7 @@ rootProto.setRenderPipeline = function (customPipeline: boolean) {
     if (customPipeline) {
         cclegacy.rendering.createCustomPipeline();
         ppl = oldSetPipeline.call(this, null);
-        log(`Using custom pipeline: ${macro.CUSTOM_PIPELINE_NAME}`);
+        debug(`Using custom pipeline: ${macro.CUSTOM_PIPELINE_NAME}`);
     } else {
         // pipeline should not be created in C++, ._ctor need to be triggered
         if (cclegacy.legacy_rendering) {

--- a/cocos/root.ts
+++ b/cocos/root.ts
@@ -23,7 +23,7 @@
 */
 
 import { USE_XR } from 'internal:constants';
-import { Pool, cclegacy, warnID, settings, macro, log, errorID, SettingsCategory } from './core';
+import { Pool, cclegacy, warnID, settings, macro, log, errorID, SettingsCategory, debug } from './core';
 import { DebugView } from './rendering/debug-view';
 import { Camera, CameraType, Light, Model, TrackingType } from './render-scene/scene';
 import type { DataPoolManager } from './3d/skeletal-animation/data-pool-manager';
@@ -380,11 +380,11 @@ export class Root {
             isCreateDefaultPipeline = true;
             this._pipeline = this._customPipeline!;
             // Use default _pipelineEvent
-            log(`Using custom pipeline: ${macro.CUSTOM_PIPELINE_NAME}`);
+            debug(`Using custom pipeline: ${macro.CUSTOM_PIPELINE_NAME}`);
         } else {
             const rppl: (PipelineRuntime & IPipelineEvent) = legacy_rendering.createDefaultPipeline();
             isCreateDefaultPipeline = true;
-            log(`Using legacy pipeline`);
+            debug(`Using legacy pipeline`);
 
             this._classicPipeline = rppl!;
             this._pipeline = this._classicPipeline;


### PR DESCRIPTION
Re: #

### Changelog

* Downgrade verbose startup and backend selection messages from normal logs to debug logs.
* Keep physics, physics2D, meshopt decoder, and render pipeline initialization details available in debug output without printing them during normal startup.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.