### PR TITLE
Fix simulated touch state on repeated mouse down

### DIFF
--- a/cocos/input/input.ts
+++ b/cocos/input/input.ts
@@ -320,6 +320,13 @@ export class Input {
     private _simulateEventTouch (eventMouse: EventMouse): void {
         const eventType = pointerEventTypeMap[eventMouse.type];
         const touchID = 0;
+        const previousTouch = touchManager.getTouch(touchID);
+        if (eventType === InputEventType.TOUCH_START && previousTouch) {
+            const eventTouchCancel = new EventTouch([previousTouch], false, InputEventType.TOUCH_CANCEL, []);
+            eventTouchCancel.windowId = eventMouse.windowId;
+            touchManager.releaseTouch(touchID);
+            this._dispatchEventTouch(eventTouchCancel);
+        }
         const touch = touchManager.getOrCreateTouch(touchID, eventMouse.getLocationX(), eventMouse.getLocationY());
         if (!touch) {
             return;

--- a/tests/core/input.test.ts
+++ b/tests/core/input.test.ts
@@ -1,0 +1,50 @@
+import { Input } from '../../cocos/input';
+import { EventTouch } from '../../cocos/input/types';
+import { InputEventType } from '../../cocos/input/types/event-enum';
+import { touchManager } from '../../pal/input/touch-manager';
+
+type InputPrivateMouseDispatch = {
+    _dispatchMouseDownEvent: (nativeMouseEvent: MouseEvent) => void;
+    _dispatchMouseUpEvent: (nativeMouseEvent: MouseEvent) => void;
+};
+
+function createNativeMouseEvent (clientX: number, clientY: number, buttons: number): MouseEvent {
+    return {
+        button: 0,
+        buttons,
+        clientX,
+        clientY,
+        movementX: 0,
+        movementY: 0,
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+    } as unknown as MouseEvent;
+}
+
+afterEach(() => {
+    touchManager.releaseTouch(0);
+});
+
+test('simulated touch cancels the previous touch before a repeated mouse down', () => {
+    const testInput = new Input();
+    const privateInput = testInput as unknown as InputPrivateMouseDispatch;
+    const receivedEvents: InputEventType[] = [];
+    const recordTouchEvent = (eventTouch: EventTouch): void => {
+        receivedEvents.push(eventTouch.type as InputEventType);
+    };
+
+    testInput.on(Input.EventType.TOUCH_START, recordTouchEvent);
+    testInput.on(Input.EventType.TOUCH_END, recordTouchEvent);
+    testInput.on(Input.EventType.TOUCH_CANCEL, recordTouchEvent);
+
+    privateInput._dispatchMouseDownEvent(createNativeMouseEvent(10, 20, 1));
+    privateInput._dispatchMouseDownEvent(createNativeMouseEvent(30, 40, 1));
+    privateInput._dispatchMouseUpEvent(createNativeMouseEvent(30, 40, 0));
+
+    expect(receivedEvents).toEqual([
+        Input.EventType.TOUCH_START,
+        Input.EventType.TOUCH_CANCEL,
+        Input.EventType.TOUCH_START,
+        Input.EventType.TOUCH_END,
+    ]);
+});


### PR DESCRIPTION
## Summary

Fix simulated touch lifecycle handling when mouse down/up events are not paired. If a new mouse down arrives while the simulated touch is still active, the previous simulated touch is now cancelled before emitting the new touch start.

## Problem

Mouse events are not guaranteed to arrive as perfectly paired `mousedown`/`mouseup` sequences. For example, a user can press on the canvas, keep the mouse button pressed while moving outside the canvas, release elsewhere, then move back into the canvas and click again. This is easier to hit when:

- The page contains elements other than the canvas, so the pointer can move onto another element.
- A debugger is triggered while the mouse button is pressed.

Before this change, the simulated touch sequence could become `touch-start, touch-start, touch-end`. In most touch workflows, a new touch start while the previous simulated touch is still active is unexpected.

## Fix

When simulating touch from mouse input, the engine uses touch id `0`. On a new simulated `TOUCH_START`, if touch id `0` is still alive, we first dispatch `TOUCH_CANCEL` for the previous touch and release it from `touchManager`. The new mouse down can then create a fresh simulated touch and dispatch the expected `TOUCH_START`.

This keeps the simulated touch lifecycle well formed:

```text
mousedown, mousedown, mouseup
=> touch-start, touch-cancel, touch-start, touch-end
```

## Reproduction

The following standalone page demonstrates that element-level mouse events can become unpaired. Press inside the canvas, drag to the gray area, release there, then move back into the canvas and click again. The canvas receives the second `mousedown` without receiving the first `mouseup`.

```html
<!doctype html>
<html>
<body>
  <canvas id="canvas" width="360" height="180" style="border: 1px solid #333"></canvas>
  <div style="width: 360px; height: 120px; margin-top: 16px; background: #eee; display: flex; align-items: center; justify-content: center;">
    Release mouse here
  </div>
  <pre id="log"></pre>

  <script>
    const canvas = document.getElementById('canvas');
    const log = document.getElementById('log');

    for (const type of ['mousedown', 'mouseup', 'mouseleave', 'mouseenter']) {
      canvas.addEventListener(type, (event) => {
        log.textContent += `${type} button=${event.button} buttons=${event.buttons}\n`;
      });
    }
  </script>
</body>
</html>
```

## Tests

```text
./node_modules/.bin/jest.cmd tests/core/input.test.ts --runInBand
```