### PR TITLE
fix(minigame): refactor LRU cache cleanup in cache-manager

### DIFF
--- a/platforms/minigame/common/engine/cache-manager.js
+++ b/platforms/minigame/common/engine/cache-manager.js
@@ -31,8 +31,8 @@ const {
 let checkNextPeriod = false;
 let writeCacheFileList = null;
 let startWrite = false;
-let nextCallbacks = [];
-let callbacks = [];
+const nextCallbacks = [];
+const callbacks = [];
 let cleaning = false;
 let suffix = 0;
 const REGEX = /^https?:\/\/.*/;
@@ -54,6 +54,9 @@ const cacheManager = {
     cacheInterval: 500,
 
     deleteInterval: 500,
+
+    // delete multiple files per cycle when clearing LRU caches
+    deleteBatchCount: 30,
 
     writeFileInterval: 2000,
 
@@ -105,7 +108,7 @@ const cacheManager = {
     _write () {
         writeCacheFileList = null;
         startWrite = true;
-        writeFile(this.cacheDir + '/' + this.cachedFileName, JSON.stringify({ files: this.cachedFiles._map, version: this.version }), 'utf8', function () {
+        writeFile(`${this.cacheDir}/${this.cachedFileName}`, JSON.stringify({ files: this.cachedFiles._map, version: this.version }), 'utf8', () => {
             startWrite = false;
             for (let i = 0, j = callbacks.length; i < j; i++) {
                 callbacks[i]();
@@ -121,8 +124,7 @@ const cacheManager = {
             writeCacheFileList = setTimeout(this._write.bind(this), this.writeFileInterval);
             if (startWrite === true) {
                 cb && nextCallbacks.push(cb);
-            }
-            else {
+            } else {
                 cb && callbacks.push(cb);
             }
         } else {
@@ -140,11 +142,10 @@ const cacheManager = {
 
             if (cacheBundleRoot) {
                 localPath = `${this.cacheDir}/${cacheBundleRoot}/${time}${suffix++}${cc.path.extname(id)}`;
-            }
-            else {
+            } else {
                 localPath = `${this.cacheDir}/${time}${suffix++}${cc.path.extname(id)}`;
             }
-            
+
             function callback (err) {
                 checkNextPeriod = false;
                 if (err)  {
@@ -165,8 +166,7 @@ const cacheManager = {
             }
             if (!isCopy) {
                 downloadFile(srcUrl, localPath, null, callback);
-            }
-            else {
+            } else {
                 copyFile(srcUrl, localPath, callback);
             }
             return;
@@ -183,8 +183,7 @@ const cacheManager = {
             checkNextPeriod = true;
             if (!this.outOfStorage) {
                 setTimeout(this._cache.bind(this), this.cacheInterval);
-            }
-            else {
+            } else {
                 checkNextPeriod = false;
             }
         }
@@ -194,12 +193,12 @@ const cacheManager = {
         rmdirSync(this.cacheDir, true);
         this.cachedFiles = new cc.AssetManager.Cache();
         makeDirSync(this.cacheDir, true);
-        const cacheFilePath = this.cacheDir + '/' + this.cachedFileName;
+        const cacheFilePath = `${this.cacheDir}/${this.cachedFileName}`;
         this.outOfStorage = false;
         clearTimeout(writeCacheFileList);
         writeCacheFileList = null;
         writeFileSync(cacheFilePath, JSON.stringify({ files: this.cachedFiles._map, version: this.version }), 'utf8');
-        cc.assetManager.bundles.forEach(bundle => {
+        cc.assetManager.bundles.forEach((bundle) => {
             if (REGEX.test(bundle.base)) this.makeBundleFolder(bundle.name);
         });
     },
@@ -214,27 +213,28 @@ const cacheManager = {
             caches.push({ originUrl: key, url: val.url, lastTime: val.lastTime });
         });
         caches.sort((a, b) => a.lastTime - b.lastTime);
-        // cache length above 3 then clear 1/2, or clear all caches
+        // cache length above 3 then clear 1/3, or clear all caches
         if (caches.length < 3) {
             console.warn('Insufficient storage, cleaning now');
         } else {
-            caches.length = Math.floor(caches.length / 2);
+            caches.length = Math.floor(caches.length / 3);
         }
         for (let i = 0, l = caches.length; i < l; i++) {
             const cacheKey = `${cc.assetManager.utils.getUuidFromURL(caches[i].originUrl)}@native`;
             cc.assetManager.files.remove(cacheKey);
             this.cachedFiles.remove(caches[i].originUrl);
         }
-        
+
         clearTimeout(writeCacheFileList);
         writeCacheFileList = null;
-        this.writeCacheFile(function () {
+        this.writeCacheFile(() => {
             self._deleteLRUCaches(caches);
         });
     },
 
     _deleteLRUCaches (caches) {
         const self = this;
+        const deleteBatchCount = Math.max(1, this.deleteBatchCount || 1);
         let index = 0;
         let pending = 0;
         let removed = false;
@@ -266,11 +266,22 @@ const cacheManager = {
         }
 
         function deleteBatch () {
-            for (; index < caches.length; index++) {
+            const end = Math.min(index + deleteBatchCount, caches.length);
+            for (; index < end; index++) {
                 pending++;
                 self._removePathOrFile(caches[index].originUrl, caches[index].url, onDeleted);
             }
-            if (pending === 0) {
+            const endTime = Date.now();
+            console.warn(`${LOG_PREFIX} delete batch：`, {
+                count: end,
+                removed,
+                startTime,
+                endTime,
+                durationMs: endTime - startTime,
+            });
+            if (index < caches.length) {
+                setTimeout(deleteBatch, self.deleteInterval);
+            } else if (pending === 0) {
                 finish();
             }
         }
@@ -284,7 +295,7 @@ const cacheManager = {
             const path = this.cachedFiles.remove(url).url;
             clearTimeout(writeCacheFileList);
             writeCacheFileList = null;
-            this.writeCacheFile(function () {
+            this.writeCacheFile(() => {
                 self._removePathOrFile(url, path);
             });
         }

--- a/platforms/minigame/common/engine/cache-manager.js
+++ b/platforms/minigame/common/engine/cache-manager.js
@@ -36,6 +36,7 @@ let callbacks = [];
 let cleaning = false;
 let suffix = 0;
 const REGEX = /^https?:\/\/.*/;
+const LOG_PREFIX = '[CacheManager]';
 
 const cacheManager = {
 
@@ -78,6 +79,10 @@ const cacheManager = {
     init () {
         this.cacheDir = `${getUserDataPath()}/${this.cacheDir}`;
         const cacheFilePath = `${this.cacheDir}/${this.cachedFileName}`;
+        console.warn(`${LOG_PREFIX} init storage`, {
+            cacheDir: this.cacheDir,
+            cacheFilePath,
+        });
         const result = readJsonSync(cacheFilePath);
         if (result instanceof Error || !result.version) {
             if (!(result instanceof Error)) rmdirSync(this.cacheDir, true);
@@ -209,11 +214,11 @@ const cacheManager = {
             caches.push({ originUrl: key, url: val.url, lastTime: val.lastTime });
         });
         caches.sort((a, b) => a.lastTime - b.lastTime);
-        // cache length above 3 then clear 1/3, or clear all caches
+        // cache length above 3 then clear 1/2, or clear all caches
         if (caches.length < 3) {
             console.warn('Insufficient storage, cleaning now');
         } else {
-            caches.length = Math.floor(caches.length / 3);
+            caches.length = Math.floor(caches.length / 2);
         }
         for (let i = 0, l = caches.length; i < l; i++) {
             const cacheKey = `${cc.assetManager.utils.getUuidFromURL(caches[i].originUrl)}@native`;
@@ -224,18 +229,53 @@ const cacheManager = {
         clearTimeout(writeCacheFileList);
         writeCacheFileList = null;
         this.writeCacheFile(function () {
-            function deferredDelete () {
-                const item = caches.pop();
-                self._removePathOrFile(item.originUrl, item.url);
-                if (caches.length > 0) { 
-                    setTimeout(deferredDelete, self.deleteInterval); 
-                }
-                else {
-                    cleaning = false;
-                }
-            }
-            setTimeout(deferredDelete, self.deleteInterval);
+            self._deleteLRUCaches(caches);
         });
+    },
+
+    _deleteLRUCaches (caches) {
+        const self = this;
+        let index = 0;
+        let pending = 0;
+        let removed = false;
+        const startTime = Date.now();
+        console.warn(`${LOG_PREFIX} delete LRU caches start`, {
+            count: caches.length,
+            startTime,
+        });
+
+        function finish () {
+            const endTime = Date.now();
+            console.warn(`${LOG_PREFIX} delete LRU caches finished`, {
+                count: caches.length,
+                removed,
+                startTime,
+                endTime,
+                durationMs: endTime - startTime,
+            });
+            if (removed) self.outOfStorage = false;
+            cleaning = false;
+        }
+
+        function onDeleted (err) {
+            if (!err) removed = true;
+            pending--;
+            if (index >= caches.length && pending === 0) {
+                finish();
+            }
+        }
+
+        function deleteBatch () {
+            for (; index < caches.length; index++) {
+                pending++;
+                self._removePathOrFile(caches[index].originUrl, caches[index].url, onDeleted);
+            }
+            if (pending === 0) {
+                finish();
+            }
+        }
+
+        deleteBatch();
     },
 
     removeCache (url) {
@@ -250,16 +290,24 @@ const cacheManager = {
         }
     },
 
-    _removePathOrFile (url, path) {
+    _removePathOrFile (url, path, onComplete) {
+        const cb = (err) => {
+            this._deleteFileCB(err);
+            onComplete && onComplete(err);
+        };
         if (this._isZipFile(url)) {
             if (this._isZipFile(path)) {
-                deleteFile(path, this._deleteFileCB.bind(this));
+                deleteFile(path, cb);
             } else {
-                rmdirSync(path, true);
-                this._deleteFileCB();
+                try {
+                    rmdirSync(path, true);
+                    cb();
+                } catch (err) {
+                    cb(err);
+                }
             }
         } else {
-            deleteFile(path, this._deleteFileCB.bind(this));
+            deleteFile(path, cb);
         }
     },
 


### PR DESCRIPTION
- Change cache eviction ratio from 1/3 to 1/2
- Extract _deleteLRUCaches() for concurrent deletion with callbacks
- Add onComplete callback to _removePathOrFile for deletion tracking
- Add LOG_PREFIX logging for init and LRU deletion lifecycle

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
