### PR TITLE
Add component coroutine support

### DIFF
--- a/cocos/game/director.ts
+++ b/cocos/game/director.ts
@@ -778,6 +778,8 @@ export class Director extends EventTarget {
                 this._compScheduler.startPhase();
                 // Update for components
                 this._compScheduler.updatePhase(dt);
+                // Update coroutines
+                this._compScheduler.coroutineUpdatePhase(dt, this._totalFrames);
                 // Update systems
                 for (let i = 0; i < this._systems.length; ++i) {
                     this._systems[i].update(dt);

--- a/cocos/scene-graph/component-coroutine.ts
+++ b/cocos/scene-graph/component-coroutine.ts
@@ -1,0 +1,437 @@
+/*
+ Copyright (c) 2026 Xiamen Yaji Software Co., Ltd.
+
+ http://www.cocos.com
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+/**
+ * Frame data passed to a coroutine when it resumes.
+ */
+export interface CoroutineFrame {
+    /**
+     * Time elapsed since the previous coroutine update, in seconds.
+     */
+    readonly deltaTime: number;
+
+    /**
+     * Time elapsed since this coroutine started running, in seconds.
+     */
+    readonly elapsedTime: number;
+
+    /**
+     * Number of coroutine update frames since the owner component started running coroutines.
+     */
+    readonly frame: number;
+}
+
+declare const CoroutineBrand: unique symbol;
+
+/**
+ * Handle returned by `Component.startCoroutine`.
+ */
+export interface Coroutine {
+    readonly [CoroutineBrand]: never;
+}
+
+declare const CoroutineInstructionBrand: unique symbol;
+
+/**
+ * Yield instruction returned by coroutine wait helpers.
+ */
+export interface CoroutineInstruction {
+    readonly [CoroutineInstructionBrand]: never;
+}
+
+/**
+ * Iterator shape accepted by `Component.startCoroutine`.
+ */
+export type CoroutineIterator = Generator<CoroutineYield, void, CoroutineFrame>;
+
+/**
+ * Predicate evaluated with the current coroutine frame.
+ */
+export type CoroutinePredicate = (frame: CoroutineFrame) => boolean;
+
+interface CoroutineAbortSignal {
+    readonly aborted: boolean;
+    addEventListener?: (type: 'abort', listener: () => void) => void;
+    removeEventListener?: (type: 'abort', listener: () => void) => void;
+}
+
+/**
+ * Options used when starting a component coroutine.
+ */
+export interface StartCoroutineOptions {
+    /**
+     * Abort signal that stops the coroutine when aborted.
+     */
+    readonly signal?: CoroutineAbortSignal;
+}
+
+type CoroutineYield = CoroutineInstruction | null | undefined;
+
+type InternalCoroutineInstruction =
+    | NextFrameInstruction
+    | WaitForInstruction
+    | WaitUntilInstruction
+    | WaitWhileInstruction;
+
+enum CoroutineInstructionType {
+    NEXT_FRAME = 0,
+    WAIT_FOR = 1,
+    WAIT_UNTIL = 2,
+    WAIT_WHILE = 3,
+}
+
+interface NextFrameInstruction extends CoroutineInstruction {
+    readonly type: CoroutineInstructionType.NEXT_FRAME;
+}
+
+interface WaitForInstruction extends CoroutineInstruction {
+    readonly type: CoroutineInstructionType.WAIT_FOR;
+    readonly seconds: number;
+}
+
+interface WaitUntilInstruction extends CoroutineInstruction {
+    readonly type: CoroutineInstructionType.WAIT_UNTIL;
+    readonly predicate: CoroutinePredicate;
+}
+
+interface WaitWhileInstruction extends CoroutineInstruction {
+    readonly type: CoroutineInstructionType.WAIT_WHILE;
+    readonly predicate: CoroutinePredicate;
+}
+
+const NEXT_FRAME_INSTRUCTION = {
+    type: CoroutineInstructionType.NEXT_FRAME,
+} as NextFrameInstruction;
+
+/**
+ * Resume the coroutine on the next coroutine update.
+ */
+export function nextFrame (): CoroutineInstruction {
+    return NEXT_FRAME_INSTRUCTION;
+}
+
+/**
+ * Resume the coroutine after at least the given duration.
+ */
+export function waitFor (seconds: number): CoroutineInstruction {
+    if (!Number.isFinite(seconds) || seconds < 0) {
+        throw new Error('seconds must be a non-negative finite number.');
+    }
+
+    return {
+        type: CoroutineInstructionType.WAIT_FOR,
+        seconds,
+    } as WaitForInstruction;
+}
+
+/**
+ * Resume the coroutine when the predicate becomes true.
+ */
+export function waitUntil (predicate: CoroutinePredicate): CoroutineInstruction {
+    return {
+        type: CoroutineInstructionType.WAIT_UNTIL,
+        predicate,
+    } as WaitUntilInstruction;
+}
+
+/**
+ * Resume the coroutine when the predicate becomes false.
+ */
+export function waitWhile (predicate: CoroutinePredicate): CoroutineInstruction {
+    return {
+        type: CoroutineInstructionType.WAIT_WHILE,
+        predicate,
+    } as WaitWhileInstruction;
+}
+
+export class CoroutineRunner {
+    public start (coroutine: CoroutineIterator, firstResumeFrame: number, opts?: StartCoroutineOptions): Coroutine {
+        const record = new CoroutineRecord(this, coroutine, opts);
+        this._records.push(record);
+        try {
+            record.start(firstResumeFrame);
+        } finally {
+            this._pruneIfNotDeferred();
+        }
+        return record;
+    }
+
+    public update (deltaTime: number, directorFrame: number): void {
+        this._frame++;
+        this._deltaTime = deltaTime;
+        this._directorFrame = directorFrame;
+
+        this._beginPruneDeferral();
+        try {
+            const count = this._records.length;
+            for (let i = 0; i < count; i++) {
+                this._records[i].update();
+            }
+        } finally {
+            this._endPruneDeferral();
+        }
+    }
+
+    public stop (handle: Coroutine): void {
+        stopCoroutine(handle);
+        this._pruneIfNotDeferred();
+    }
+
+    public stopAll (): void {
+        this._beginPruneDeferral();
+        try {
+            const count = this._records.length;
+            for (let i = 0; i < count; i++) {
+                this._records[i].stop();
+            }
+        } finally {
+            this._endPruneDeferral();
+        }
+    }
+
+    public get frame (): number {
+        return this._frame;
+    }
+
+    public get deltaTime (): number {
+        return this._deltaTime;
+    }
+
+    public get directorFrame (): number {
+        return this._directorFrame;
+    }
+
+    public get empty (): boolean {
+        return this._records.length === 0;
+    }
+
+    private _records: CoroutineRecord[] = [];
+    private _frame = 0;
+    private _deltaTime = 0;
+    private _directorFrame = 0;
+    private _pruneDeferralDepth = 0;
+
+    private _beginPruneDeferral (): void {
+        this._pruneDeferralDepth++;
+    }
+
+    private _endPruneDeferral (): void {
+        this._pruneDeferralDepth--;
+        if (this._pruneDeferralDepth === 0) {
+            this._prune();
+        }
+    }
+
+    private _pruneIfNotDeferred (): void {
+        if (this._pruneDeferralDepth === 0) {
+            this._prune();
+        }
+    }
+
+    private _prune (): void {
+        this._records = this._records.filter((record): boolean => !record.done);
+    }
+}
+
+export function stopCoroutine (coroutine: Coroutine): void {
+    if (coroutine instanceof CoroutineRecord) {
+        coroutine.stop();
+        return;
+    }
+
+    throw new Error('Invalid coroutine handle.');
+}
+
+class CoroutineRecord implements Coroutine {
+    public declare readonly [CoroutineBrand]: never;
+
+    constructor (runner: CoroutineRunner, coroutine: CoroutineIterator, opts?: StartCoroutineOptions) {
+        this._runner = runner;
+        this._coroutine = coroutine;
+        this._signal = opts?.signal;
+    }
+
+    public get running (): boolean {
+        return !this._done && !this._stopping;
+    }
+
+    public get done (): boolean {
+        return this._done;
+    }
+
+    public start (firstResumeFrame: number): void {
+        if (this._signal?.aborted) {
+            this.stop();
+            return;
+        }
+
+        this._addAbortListener();
+        this._advance(undefined, firstResumeFrame);
+    }
+
+    public update (): void {
+        if (!this.running || this._runner.directorFrame < this._resumeAfterDirectorFrame || this._yieldedAtFrame >= this._runner.frame) {
+            return;
+        }
+
+        this._elapsedTime += this._runner.deltaTime;
+        const frame: CoroutineFrame = {
+            deltaTime: this._runner.deltaTime,
+            elapsedTime: this._elapsedTime,
+            frame: this._runner.frame,
+        };
+        if (this._canResume(frame)) {
+            this._advance(frame, this._runner.directorFrame);
+        }
+    }
+
+    public stop (): void {
+        if (this._done) {
+            return;
+        }
+
+        this._done = true;
+        this._removeAbortListener();
+        if (this._executing) {
+            return;
+        }
+
+        this._stopping = true;
+        try {
+            this._coroutine.return?.(undefined);
+        } finally {
+            this._stopping = false;
+        }
+    }
+
+    private readonly _runner: CoroutineRunner;
+    private readonly _coroutine: CoroutineIterator;
+    private readonly _signal: CoroutineAbortSignal | undefined;
+
+    private _instruction: InternalCoroutineInstruction = NEXT_FRAME_INSTRUCTION;
+    private _yieldedAtFrame = 0;
+    private _resumeAfterDirectorFrame = 0;
+    private _remainingSeconds = 0;
+    private _elapsedTime = 0;
+    private _done = false;
+    private _executing = false;
+    private _stopping = false;
+    private _onAbort: (() => void) | undefined = undefined;
+
+    private _advance (frame: CoroutineFrame | undefined, resumeAfterDirectorFrame: number): void {
+        let result: IteratorResult<CoroutineYield, void>;
+        this._executing = true;
+        try {
+            result = frame === undefined ? this._coroutine.next() : this._coroutine.next(frame);
+        } catch (error) {
+            this._done = true;
+            this._removeAbortListener();
+            throw error;
+        } finally {
+            this._executing = false;
+        }
+
+        if (this._done) {
+            return;
+        }
+
+        if (result.done === true) {
+            this._done = true;
+            this._removeAbortListener();
+            return;
+        }
+
+        try {
+            this._setInstruction(result.value, resumeAfterDirectorFrame);
+        } catch (error) {
+            this._done = true;
+            this._removeAbortListener();
+            throw error;
+        }
+    }
+
+    private _setInstruction (instruction: CoroutineYield, resumeAfterDirectorFrame: number): void {
+        if (instruction === null || instruction === undefined) {
+            this._instruction = NEXT_FRAME_INSTRUCTION;
+        } else {
+            switch ((instruction as { readonly type?: unknown }).type) {
+            case CoroutineInstructionType.NEXT_FRAME:
+                this._instruction = instruction as NextFrameInstruction;
+                break;
+            case CoroutineInstructionType.WAIT_FOR:
+                this._instruction = instruction as WaitForInstruction;
+                break;
+            case CoroutineInstructionType.WAIT_UNTIL:
+            case CoroutineInstructionType.WAIT_WHILE:
+                this._instruction = instruction as WaitUntilInstruction | WaitWhileInstruction;
+                break;
+            default:
+                throw new Error('Invalid coroutine instruction.');
+            }
+        }
+
+        this._yieldedAtFrame = this._runner.frame;
+        this._resumeAfterDirectorFrame = resumeAfterDirectorFrame;
+
+        if (this._instruction.type === CoroutineInstructionType.WAIT_FOR) {
+            this._remainingSeconds = this._instruction.seconds;
+        }
+    }
+
+    private _canResume (frame: CoroutineFrame): boolean {
+        switch (this._instruction.type) {
+        case CoroutineInstructionType.NEXT_FRAME:
+            return true;
+        case CoroutineInstructionType.WAIT_FOR:
+            this._remainingSeconds -= frame.deltaTime;
+            return this._remainingSeconds <= 0;
+        case CoroutineInstructionType.WAIT_UNTIL:
+            return this._instruction.predicate(frame);
+        case CoroutineInstructionType.WAIT_WHILE:
+            return !this._instruction.predicate(frame);
+        default:
+            return false;
+        }
+    }
+
+    private _addAbortListener (): void {
+        if (!this._signal || this._onAbort || !this._signal.addEventListener) {
+            return;
+        }
+
+        this._onAbort = (): void => {
+            this.stop();
+        };
+        this._signal.addEventListener('abort', this._onAbort);
+    }
+
+    private _removeAbortListener (): void {
+        if (!this._signal || !this._onAbort || !this._signal.removeEventListener) {
+            return;
+        }
+
+        this._signal.removeEventListener('abort', this._onAbort);
+        this._onAbort = undefined;
+    }
+}

--- a/cocos/scene-graph/component-scheduler.ts
+++ b/cocos/scene-graph/component-scheduler.ts
@@ -85,7 +85,7 @@ function stableRemoveInactive (iterator, flagToClear): void {
     }
 }
 
-export type InvokeFunc = (...args: unknown[]) => void;
+export type InvokeFunc = (iterator: any, dt?: any, directorFrame?: any) => void;
 
 // This class contains some queues used to invoke life-cycle methods by script execution order
 export class LifeCycleInvoker {
@@ -205,15 +205,15 @@ class ReusableInvoker extends LifeCycleInvoker {
         }
     }
 
-    public invoke (dt: number): void {
+    public invoke (dt: number, directorFrame?: number): void {
         if (this._neg.array.length > 0) {
-            this._invoke(this._neg, dt);
+            this._invoke(this._neg, dt, directorFrame);
         }
 
-        this._invoke(this._zero, dt);
+        this._invoke(this._zero, dt, directorFrame);
 
         if (this._pos.array.length > 0) {
-            this._invoke(this._pos, dt);
+            this._invoke(this._pos, dt, directorFrame);
         }
     }
 }
@@ -228,7 +228,7 @@ function enableInEditor (comp): void {
 }
 
 // return function to simply call each component with try catch protection
-export function createInvokeImplJit (code: string, useDt?, ensureFlag?): (iterator: any, dt: any) => void {
+export function createInvokeImplJit (code: string, useDt?, ensureFlag?): (iterator: any, dt?: any, directorFrame?: any) => void {
     // function (it) {
     //     let a = it.array;
     //     for (it.i = 0; it.i < a.length; ++it.i) {
@@ -245,10 +245,10 @@ export function createInvokeImplJit (code: string, useDt?, ensureFlag?): (iterat
     const singleInvoke = Function('c', 'dt', code);
     return createInvokeImpl(singleInvoke, fastPath, ensureFlag);
 }
-export function createInvokeImpl (singleInvoke, fastPath, ensureFlag?): (iterator: any, dt: any) => void {
-    return (iterator, dt: number): void => {
+export function createInvokeImpl (singleInvoke, fastPath, ensureFlag?): (iterator: any, dt?: any, directorFrame?: any) => void {
+    return (iterator, dt: number, directorFrame?: number): void => {
         try {
-            fastPath(iterator, dt);
+            fastPath(iterator, dt, directorFrame);
         } catch (e) {
             // slow path
             legacyCC._throw(e);
@@ -259,7 +259,7 @@ export function createInvokeImpl (singleInvoke, fastPath, ensureFlag?): (iterato
             ++iterator.i;   // invoke next callback
             for (; iterator.i < array.length; ++iterator.i) {
                 try {
-                    singleInvoke(array[iterator.i], dt);
+                    singleInvoke(array[iterator.i], dt, directorFrame);
                 } catch (e) {
                     legacyCC._throw(e);
                     if (ensureFlag) {
@@ -314,6 +314,18 @@ const invokeLateUpdate = SUPPORT_JIT ? createInvokeImplJit('c.lateUpdate(dt)', t
         },
     );
 
+const invokeCoroutineUpdate = createInvokeImpl(
+    (c, dt: number, directorFrame: number): void => {
+        c._invokeCoroutineUpdate(dt, directorFrame);
+    },
+    (iterator, dt: number, directorFrame: number): void => {
+        const array = iterator.array;
+        for (iterator.i = 0; iterator.i < array.length; ++iterator.i) {
+            array[iterator.i]._invokeCoroutineUpdate(dt, directorFrame);
+        }
+    },
+);
+
 export const invokeOnEnable = EDITOR ? (iterator): void => {
     const compScheduler = legacyCC.director._compScheduler;
     const array = iterator.array;
@@ -364,9 +376,16 @@ export class ComponentScheduler {
      * @zh `lateUpdate` 回调的调度器
      */
     public declare lateUpdateInvoker: ReusableInvoker;
+    /**
+     * @en The invoker of component coroutine callbacks
+     * @zh 组件协程回调的调度器
+     */
+    public declare coroutineInvoker: ReusableInvoker;
     // components deferred to schedule
     private _deferredComps: any[] = [];
+    private _deferredCoroutineComps: Component[] = [];
     private declare _updating: boolean;
+    private _invokingCoroutines = false;
 
     constructor () {
         this.unscheduleAll();
@@ -381,9 +400,12 @@ export class ComponentScheduler {
         this.startInvoker = new OneOffInvoker(invokeStart);
         this.updateInvoker = new ReusableInvoker(invokeUpdate);
         this.lateUpdateInvoker = new ReusableInvoker(invokeLateUpdate);
+        this.coroutineInvoker = new ReusableInvoker(invokeCoroutineUpdate);
 
         // during a loop
         this._updating = false;
+        this._invokingCoroutines = false;
+        this._deferredCoroutineComps.length = 0;
     }
 
     /**
@@ -505,6 +527,55 @@ export class ComponentScheduler {
     }
 
     /**
+     * @en Process coroutine phase for registered components
+     * @zh 为当前注册的组件执行协程阶段任务
+     * @param dt @en Time passed after the last frame in seconds @zh 距离上一帧的时间，以秒计算
+     * @param directorFrame @en Current director frame @zh 当前导演帧号
+     */
+    public coroutineUpdatePhase (dt: number, directorFrame: number): void {
+        this._invokingCoroutines = true;
+        try {
+            this.coroutineInvoker.invoke(dt, directorFrame);
+        } finally {
+            this._invokingCoroutines = false;
+            this._deferredScheduleCoroutine();
+        }
+    }
+
+    /**
+     * @engineInternal
+     */
+    public getCoroutineResumeFrame (): number {
+        return legacyCC.director.getTotalFrames() + (this._updating ? 1 : 0);
+    }
+
+    /**
+     * @engineInternal
+     */
+    public enableCoroutine (comp: Component): void {
+        if (this._invokingCoroutines) {
+            if (this._deferredCoroutineComps.indexOf(comp) < 0) {
+                this._deferredCoroutineComps.push(comp);
+            }
+        } else {
+            this._scheduleCoroutineImmediate(comp);
+        }
+    }
+
+    /**
+     * @engineInternal
+     */
+    public disableCoroutine (comp: Component): void {
+        const index = this._deferredCoroutineComps.indexOf(comp);
+        if (index >= 0) {
+            fastRemoveAt(this._deferredCoroutineComps, index);
+            return;
+        }
+
+        this.coroutineInvoker.remove(comp);
+    }
+
+    /**
      * @en Process late update phase for registered components
      * @zh 为当前注册的组件执行 late update 阶段任务
      * @param dt @en Time passed after the last frame in seconds @zh 距离上一帧的时间，以秒计算
@@ -541,10 +612,22 @@ export class ComponentScheduler {
         }
     }
 
+    private _scheduleCoroutineImmediate (comp: Component): void {
+        this.coroutineInvoker.add(comp);
+    }
+
     private _deferredSchedule (): void {
         const comps = this._deferredComps;
         for (let i = 0, len = comps.length; i < len; i++) {
             this._scheduleImmediate(comps[i]);
+        }
+        comps.length = 0;
+    }
+
+    private _deferredScheduleCoroutine (): void {
+        const comps = this._deferredCoroutineComps;
+        for (let i = 0, len = comps.length; i < len; i++) {
+            this._scheduleCoroutineImmediate(comps[i]);
         }
         comps.length = 0;
     }

--- a/cocos/scene-graph/component.ts
+++ b/cocos/scene-graph/component.ts
@@ -37,6 +37,13 @@ import { legacyCC } from '../core/global-exports';
 import { errorID, warnID, assertID } from '../core/platform/debug';
 import { CompPrefabInfo } from './prefab/prefab-info';
 import { EventHandler } from './component-event-handler';
+import {
+    CoroutineRunner,
+    stopCoroutine as stopCoroutineRecord,
+    type Coroutine,
+    type CoroutineIterator,
+    type StartCoroutineOptions,
+} from './component-coroutine';
 
 const idGenerator = new IDGenerator('Comp');
 const IsOnLoadCalled = CCObjectFlags.IsOnLoadCalled;
@@ -211,6 +218,9 @@ class Component extends CCObject {
     public _id: string = idGenerator.getNewId();
 
     // private __scriptUuid = '';
+
+    private _coroutines: CoroutineRunner | undefined = undefined;
+    private _coroutineScheduled = false;
 
     /**
      * @deprecated since v3.5.0, this is an engine private interface that will be removed in the future.
@@ -394,6 +404,7 @@ class Component extends CCObject {
             if (this._enabled && this.node.activeInHierarchy) {
                 legacyCC.director._compScheduler.disableComp(this);
             }
+            this.stopAllCoroutines();
             return true;
         }
         return false;
@@ -403,6 +414,8 @@ class Component extends CCObject {
      * @deprecated since v3.5.0, this is an engine private interface that will be removed in the future.
      */
     public _onPreDestroy (): void {
+        this.stopAllCoroutines();
+
         // Schedules
         this.unscheduleAllCallbacks();
 
@@ -429,6 +442,82 @@ class Component extends CCObject {
     }
 
     // Scheduler
+
+    /**
+     * @en Starts a coroutine owned by this component.
+     * @zh 启动一个由当前组件持有的协程。
+     * @param coroutine The coroutine iterator to start.
+     * @param opts Optional start options.
+     * @returns An opaque coroutine handle that can be passed to stopCoroutine.
+     */
+    protected startCoroutine (coroutine: CoroutineIterator, opts?: StartCoroutineOptions): Coroutine {
+        const coroutines = this._coroutines ??= new CoroutineRunner();
+        let handle!: Coroutine;
+        try {
+            handle = coroutines.start(coroutine, legacyCC.director._compScheduler.getCoroutineResumeFrame(), opts);
+        } finally {
+            if (!coroutines.empty) {
+                this._enableCoroutineUpdate();
+            }
+            this._clearCoroutinesIfEmpty();
+        }
+        return handle;
+    }
+
+    /**
+     * @en Stops a coroutine.
+     * @zh 停止一个协程。
+     * @param coroutine The coroutine handle returned by startCoroutine.
+     */
+    protected stopCoroutine (coroutine: Coroutine): void {
+        if (this._coroutines) {
+            this._coroutines.stop(coroutine);
+        } else {
+            stopCoroutineRecord(coroutine);
+        }
+        this._clearCoroutinesIfEmpty();
+    }
+
+    /**
+     * @en Stops all coroutines owned by this component.
+     * @zh 停止当前组件持有的所有协程。
+     */
+    protected stopAllCoroutines (): void {
+        const coroutines = this._coroutines;
+        if (!coroutines) {
+            return;
+        }
+
+        this._coroutines = undefined;
+        this._disableCoroutineUpdate();
+        coroutines.stopAll();
+    }
+
+    /**
+     * @engineInternal
+     */
+    public _invokeCoroutineUpdate (dt: number, directorFrame: number): void {
+        const coroutines = this._coroutines;
+        if (!coroutines) {
+            this._disableCoroutineUpdate();
+            return;
+        }
+
+        if (!this.node.activeInHierarchy) {
+            this.stopAllCoroutines();
+            return;
+        }
+
+        coroutines.update(dt, directorFrame);
+        this._clearCoroutinesIfEmpty();
+    }
+
+    /**
+     * @engineInternal
+     */
+    public _stopAllCoroutines (): void {
+        this.stopAllCoroutines();
+    }
 
     /**
      * @en
@@ -511,6 +600,27 @@ class Component extends CCObject {
      */
     public unscheduleAllCallbacks (): void {
         legacyCC.director.getScheduler().unscheduleAllForTarget(this);
+    }
+
+    private _enableCoroutineUpdate (): void {
+        if (!this._coroutineScheduled) {
+            legacyCC.director._compScheduler.enableCoroutine(this);
+            this._coroutineScheduled = true;
+        }
+    }
+
+    private _disableCoroutineUpdate (): void {
+        if (this._coroutineScheduled) {
+            legacyCC.director._compScheduler.disableCoroutine(this);
+            this._coroutineScheduled = false;
+        }
+    }
+
+    private _clearCoroutinesIfEmpty (): void {
+        if (this._coroutines?.empty) {
+            this._coroutines = undefined;
+            this._disableCoroutineUpdate();
+        }
     }
 
     // LIFECYCLE METHODS

--- a/cocos/scene-graph/index.ts
+++ b/cocos/scene-graph/index.ts
@@ -37,6 +37,7 @@ export * from './node-event';
 export * from './scene-globals';
 export { EventHandler } from './component-event-handler';
 export { Component } from './component';
+export * from './component-coroutine';
 export * from './deprecated';
 export { default as NodeActivator } from './node-activator';
 export { Prefab } from './prefab';

--- a/cocos/scene-graph/node-activator.ts
+++ b/cocos/scene-graph/node-activator.ts
@@ -299,6 +299,7 @@ export default class NodeActivator {
         const originCount = node.components.length;
         for (let c = 0; c < originCount; ++c) {
             const component = node.components[c];
+            component._stopAllCoroutines();
             if (component._enabled) {
                 legacyCC.director._compScheduler.disableComp(component);
 

--- a/tests/scene-graph/component-coroutine.test.ts
+++ b/tests/scene-graph/component-coroutine.test.ts
@@ -1,0 +1,696 @@
+import {
+    Component,
+    director,
+    nextFrame,
+    Node,
+    Scene,
+    System,
+    waitFor,
+    waitUntil,
+    waitWhile,
+    type Coroutine,
+    type CoroutineIterator,
+    type StartCoroutineOptions,
+} from '../../exports/base';
+
+class CoroutineProbe extends Component {
+    public onUpdate: ((dt: number) => void) | undefined;
+    public onLateUpdate: ((dt: number) => void) | undefined;
+
+    public runCoroutine (coroutine: CoroutineIterator, opts?: StartCoroutineOptions): Coroutine {
+        return this.startCoroutine(coroutine, opts);
+    }
+
+    public stopCoroutineHandle (coroutine: Coroutine): void {
+        this.stopCoroutine(coroutine);
+    }
+
+    public stopAllCoroutineHandles (): void {
+        this.stopAllCoroutines();
+    }
+
+    protected update (dt: number): void {
+        this.onUpdate?.(dt);
+    }
+
+    protected lateUpdate (dt: number): void {
+        this.onLateUpdate?.(dt);
+    }
+}
+
+class RecordingSystem extends System {
+    constructor (private readonly _events: string[]) {
+        super();
+    }
+
+    public update (): void {
+        this._events.push('system');
+    }
+}
+
+let scene: Scene | undefined;
+let systems: System[] = [];
+
+afterEach(() => {
+    for (const system of systems) {
+        director.unregisterSystem(system);
+    }
+    systems = [];
+
+    scene?.destroy();
+    scene = undefined;
+});
+
+describe('Component coroutine', () => {
+    it('starts synchronously and resumes after component update with frame context', () => {
+        /// @case
+        /// 1. A component starts a coroutine outside the director tick.
+        /// 2. The coroutine yields until the next frame.
+        /// @expect
+        /// The coroutine runs to its first yield immediately, then resumes with frame data on the next tick.
+        const { component } = createProbe();
+        const events: string[] = [];
+        const frames: unknown[] = [];
+
+        component.runCoroutine((function* (): CoroutineIterator {
+            events.push('start');
+            frames.push(yield null);
+            events.push('resume');
+        })());
+
+        expect(events).toEqual(['start']);
+
+        director.tick(0.125);
+
+        expect(events).toEqual(['start', 'resume']);
+        expect(frames).toEqual([{
+            deltaTime: 0.125,
+            elapsedTime: 0.125,
+            frame: 1,
+        }]);
+    });
+
+    it('waits with frame, time, until, and while instructions', () => {
+        /// @case
+        /// 1. A coroutine yields next-frame, timed, wait-until, and wait-while instructions.
+        /// 2. The waited predicates change across later director ticks.
+        /// @expect
+        /// Each instruction resumes only after its own wait condition is satisfied.
+        const { component } = createProbe();
+        const events: string[] = [];
+        const frames: unknown[] = [];
+        let ready = false;
+        let blocking = true;
+
+        component.runCoroutine((function* (): CoroutineIterator {
+            events.push('start');
+            frames.push(yield nextFrame());
+            events.push('after-frame');
+            frames.push(yield waitFor(0.25));
+            events.push('after-time');
+            frames.push(yield waitUntil((): boolean => ready));
+            events.push('after-until');
+            frames.push(yield waitWhile((): boolean => blocking));
+            events.push('after-while');
+        })());
+
+        director.tick(0.1);
+        expect(events).toEqual(['start', 'after-frame']);
+        expect(frames).toEqual([expect.objectContaining({ frame: 1 })]);
+
+        director.tick(0.1);
+        expect(events).toEqual(['start', 'after-frame']);
+
+        director.tick(0.15);
+        expect(events).toEqual(['start', 'after-frame', 'after-time']);
+        expect(frames).toEqual([
+            expect.objectContaining({ frame: 1 }),
+            expect.objectContaining({ elapsedTime: expect.closeTo(0.35) }),
+        ]);
+
+        director.tick(0.1);
+        expect(events).toEqual(['start', 'after-frame', 'after-time']);
+
+        ready = true;
+        director.tick(0.1);
+        expect(events).toEqual(['start', 'after-frame', 'after-time', 'after-until']);
+
+        director.tick(0.1);
+        expect(events).toEqual(['start', 'after-frame', 'after-time', 'after-until']);
+
+        blocking = false;
+        director.tick(0.1);
+        expect(events).toEqual(['start', 'after-frame', 'after-time', 'after-until', 'after-while']);
+    });
+
+    it('orders coroutine continuations after update and before systems and lateUpdate', () => {
+        /// @case
+        /// 1. A component has update, a resumed coroutine, and lateUpdate.
+        /// 2. A director system is registered for the same tick.
+        /// @expect
+        /// The frame order is component update, coroutine continuation, system update, then component lateUpdate.
+        const { component } = createProbe();
+        const events: string[] = [];
+        const system = new RecordingSystem(events);
+        systems.push(system);
+        director.registerSystem('component-coroutine-order-test', system, System.Priority.MEDIUM);
+
+        component.onUpdate = (): void => {
+            events.push('update');
+        };
+        component.onLateUpdate = (): void => {
+            events.push('lateUpdate');
+        };
+        component.runCoroutine((function* (): CoroutineIterator {
+            yield nextFrame();
+            events.push('coroutine');
+        })());
+
+        director.tick(0.1);
+
+        expect(events).toEqual(['update', 'coroutine', 'system', 'lateUpdate']);
+    });
+
+    it('resumes synchronously started coroutines in start order', () => {
+        /// @case
+        /// 1. A component starts two coroutines synchronously.
+        /// 2. Both coroutines yield to later frames.
+        /// @expect
+        /// The coroutines start and resume in their start order on every coroutine update.
+        const { component } = createProbe();
+        const events: string[] = [];
+
+        component.runCoroutine((function* (): CoroutineIterator {
+            events.push('first-start');
+            yield nextFrame();
+            events.push('first-resume');
+            yield nextFrame();
+            events.push('first-resume-again');
+        })());
+        component.runCoroutine((function* (): CoroutineIterator {
+            events.push('second-start');
+            yield nextFrame();
+            events.push('second-resume');
+            yield nextFrame();
+            events.push('second-resume-again');
+        })());
+
+        expect(events).toEqual(['first-start', 'second-start']);
+
+        director.tick(0.1);
+        expect(events).toEqual(['first-start', 'second-start', 'first-resume', 'second-resume']);
+
+        director.tick(0.1);
+        expect(events).toEqual([
+            'first-start',
+            'second-start',
+            'first-resume',
+            'second-resume',
+            'first-resume-again',
+            'second-resume-again',
+        ]);
+    });
+
+    it('stops a component coroutine when its signal is aborted', () => {
+        /// @case
+        /// 1. A component starts a coroutine with an abort signal.
+        /// 2. The signal is aborted while the coroutine is waiting.
+        /// @expect
+        /// Aborting the signal stops the coroutine immediately and runs cleanup once.
+        const { component } = createProbe();
+        const controller = new AbortController();
+        const events: string[] = [];
+
+        component.runCoroutine((function* (): CoroutineIterator {
+            try {
+                events.push('start');
+                yield waitUntil((): boolean => false);
+            } finally {
+                events.push('cleanup');
+            }
+        })(), {
+            signal: controller.signal,
+        });
+
+        director.tick(0.1);
+        expect(events).toEqual(['start']);
+
+        controller.abort();
+        expect(events).toEqual(['start', 'cleanup']);
+
+        director.tick(0.1);
+        expect(events).toEqual(['start', 'cleanup']);
+    });
+    it('defers coroutines started during update to the next frame', () => {
+        /// @case
+        /// 1. A component starts a coroutine from its update callback.
+        /// 2. The coroutine yields until the next frame.
+        /// @expect
+        /// The coroutine starts immediately, but does not resume in the same frame's coroutine phase.
+        const { component } = createProbe();
+        const events: string[] = [];
+        let started = false;
+
+        component.onUpdate = (): void => {
+            events.push('update');
+            if (!started) {
+                started = true;
+                component.runCoroutine((function* (): CoroutineIterator {
+                    events.push('coroutine-start');
+                    yield nextFrame();
+                    events.push('coroutine-resume');
+                })());
+            }
+        };
+
+        director.tick(0.1);
+        expect(events).toEqual(['update', 'coroutine-start']);
+
+        events.length = 0;
+        director.tick(0.1);
+        expect(events).toEqual(['update', 'coroutine-resume']);
+    });
+
+    it('defers coroutines started during coroutine update to the next frame', () => {
+        /// @case
+        /// 1. A resumed coroutine starts another coroutine during the coroutine phase.
+        /// 2. The child coroutine yields until the next frame.
+        /// @expect
+        /// The child coroutine starts immediately and resumes on the following frame, not the current one.
+        const { component } = createProbe();
+        const events: string[] = [];
+
+        component.runCoroutine((function* (): CoroutineIterator {
+            yield nextFrame();
+            events.push('parent-resume');
+            component.runCoroutine((function* (): CoroutineIterator {
+                events.push('child-start');
+                yield nextFrame();
+                events.push('child-resume');
+            })());
+            events.push('parent-after-start');
+        })());
+
+        director.tick(0.1);
+        expect(events).toEqual(['parent-resume', 'child-start', 'parent-after-start']);
+
+        events.length = 0;
+        director.tick(0.1);
+        expect(events).toEqual(['child-resume']);
+    });
+
+    it('stops a coroutine from another coroutine', () => {
+        /// @case
+        /// 1. A component starts a child coroutine and a stopper coroutine.
+        /// 2. The stopper coroutine stops the child during a coroutine update.
+        /// @expect
+        /// The child cleanup runs immediately and the stopped child never resumes later.
+        const { component } = createProbe();
+        const events: string[] = [];
+        let childHandle: Coroutine | undefined;
+
+        childHandle = component.runCoroutine((function* (): CoroutineIterator {
+            try {
+                events.push('child-start');
+                yield waitUntil((): boolean => false);
+                events.push('child-unreachable');
+            } finally {
+                events.push('child-cleanup');
+            }
+        })());
+        component.runCoroutine((function* (): CoroutineIterator {
+            events.push('stopper-start');
+            yield nextFrame();
+            if (!childHandle) {
+                throw new Error('Expected child coroutine handle.');
+            }
+            component.stopCoroutineHandle(childHandle);
+            events.push('stopper-after-stop');
+        })());
+
+        expect(events).toEqual(['child-start', 'stopper-start']);
+
+        director.tick(0.1);
+        expect(events).toEqual(['child-start', 'stopper-start', 'child-cleanup', 'stopper-after-stop']);
+
+        director.tick(0.1);
+        expect(events).toEqual(['child-start', 'stopper-start', 'child-cleanup', 'stopper-after-stop']);
+    });
+
+    it('skips a later coroutine stopped during coroutine update', () => {
+        /// @case
+        /// 1. A component starts a stopper coroutine before a target coroutine.
+        /// 2. The stopper stops the target during the coroutine phase before the target's turn.
+        /// @expect
+        /// The target cleanup runs immediately and the target body is skipped in the same frame.
+        const { component } = createProbe();
+        const events: string[] = [];
+        let targetHandle: Coroutine | undefined;
+
+        component.runCoroutine((function* (): CoroutineIterator {
+            events.push('stopper-start');
+            yield nextFrame();
+            events.push('stopper-before-stop');
+            if (!targetHandle) {
+                throw new Error('Expected target coroutine handle.');
+            }
+            component.stopCoroutineHandle(targetHandle);
+            events.push('stopper-after-stop');
+        })());
+        targetHandle = component.runCoroutine((function* (): CoroutineIterator {
+            try {
+                events.push('target-start');
+                yield nextFrame();
+                events.push('target-resume');
+            } finally {
+                events.push('target-cleanup');
+            }
+        })());
+
+        expect(events).toEqual(['stopper-start', 'target-start']);
+
+        director.tick(0.1);
+        expect(events).toEqual([
+            'stopper-start',
+            'target-start',
+            'stopper-before-stop',
+            'target-cleanup',
+            'stopper-after-stop',
+        ]);
+
+        director.tick(0.1);
+        expect(events).toEqual([
+            'stopper-start',
+            'target-start',
+            'stopper-before-stop',
+            'target-cleanup',
+            'stopper-after-stop',
+        ]);
+    });
+
+    it('skips later coroutines after stop all during coroutine update', () => {
+        /// @case
+        /// 1. A component starts a stopper coroutine before a target coroutine.
+        /// 2. The stopper calls stopAllCoroutines during the coroutine phase.
+        /// @expect
+        /// Later coroutines are cleaned up and skipped, including the stopper's own later continuation.
+        const { component } = createProbe();
+        const events: string[] = [];
+
+        component.runCoroutine((function* (): CoroutineIterator {
+            events.push('stopper-start');
+            yield nextFrame();
+            events.push('stopper-before-stop-all');
+            component.stopAllCoroutineHandles();
+            events.push('stopper-after-stop-all');
+            yield nextFrame();
+            events.push('stopper-unreachable');
+        })());
+        component.runCoroutine((function* (): CoroutineIterator {
+            try {
+                events.push('target-start');
+                yield nextFrame();
+                events.push('target-resume');
+            } finally {
+                events.push('target-cleanup');
+            }
+        })());
+
+        expect(events).toEqual(['stopper-start', 'target-start']);
+
+        director.tick(0.1);
+        expect(events).toEqual([
+            'stopper-start',
+            'target-start',
+            'stopper-before-stop-all',
+            'target-cleanup',
+            'stopper-after-stop-all',
+        ]);
+
+        director.tick(0.1);
+        expect(events).toEqual([
+            'stopper-start',
+            'target-start',
+            'stopper-before-stop-all',
+            'target-cleanup',
+            'stopper-after-stop-all',
+        ]);
+    });
+
+    it('stops all coroutines from a coroutine', () => {
+        /// @case
+        /// 1. A component has multiple waiting coroutines and one stopper coroutine.
+        /// 2. The stopper calls stopAllCoroutines during a coroutine update.
+        /// @expect
+        /// Every waiting coroutine is cleaned up, and no stopped coroutine resumes later.
+        const { component } = createProbe();
+        const events: string[] = [];
+
+        component.runCoroutine((function* (): CoroutineIterator {
+            try {
+                events.push('first-start');
+                yield waitUntil((): boolean => false);
+                events.push('first-unreachable');
+            } finally {
+                events.push('first-cleanup');
+            }
+        })());
+        component.runCoroutine((function* (): CoroutineIterator {
+            try {
+                events.push('second-start');
+                yield waitUntil((): boolean => false);
+                events.push('second-unreachable');
+            } finally {
+                events.push('second-cleanup');
+            }
+        })());
+        component.runCoroutine((function* (): CoroutineIterator {
+            events.push('stopper-start');
+            yield nextFrame();
+            events.push('stopper-before-stop-all');
+            component.stopAllCoroutineHandles();
+            events.push('stopper-after-stop-all');
+            yield nextFrame();
+            events.push('stopper-unreachable');
+        })());
+
+        expect(events).toEqual(['first-start', 'second-start', 'stopper-start']);
+
+        director.tick(0.1);
+        expect(events).toEqual([
+            'first-start',
+            'second-start',
+            'stopper-start',
+            'stopper-before-stop-all',
+            'first-cleanup',
+            'second-cleanup',
+            'stopper-after-stop-all',
+        ]);
+
+        director.tick(0.1);
+        expect(events).toEqual([
+            'first-start',
+            'second-start',
+            'stopper-start',
+            'stopper-before-stop-all',
+            'first-cleanup',
+            'second-cleanup',
+            'stopper-after-stop-all',
+        ]);
+    });
+    it('keeps component coroutines running when the component is disabled', () => {
+        /// @case
+        /// 1. A component starts a coroutine and then the component is disabled.
+        /// 2. The owner node remains active in the hierarchy.
+        /// @expect
+        /// Disabling the component stops update callbacks but does not stop or pause its coroutine.
+        const { component } = createProbe();
+        const events: string[] = [];
+
+        component.runCoroutine((function* (): CoroutineIterator {
+            events.push('start');
+            yield nextFrame();
+            events.push('first');
+            yield nextFrame();
+            events.push('after-disabled');
+        })());
+
+        director.tick(0.1);
+        component.enabled = false;
+        director.tick(0.1);
+
+        expect(events).toEqual(['start', 'first', 'after-disabled']);
+    });
+
+    it('stops component coroutines when the node becomes inactive', () => {
+        /// @case
+        /// 1. A disabled component owns a pending coroutine.
+        /// 2. The owner node becomes inactive.
+        /// @expect
+        /// Node inactivity immediately stops the coroutine and runs cleanup even though the component was already disabled.
+        const { component, node } = createProbe();
+        const events: string[] = [];
+
+        component.runCoroutine((function* (): CoroutineIterator {
+            try {
+                events.push('start');
+                yield waitUntil((): boolean => false);
+            } finally {
+                events.push('cleanup');
+            }
+        })());
+
+        component.enabled = false;
+        node.active = false;
+
+        expect(events).toEqual(['start', 'cleanup']);
+    });
+
+    it('stops component coroutines when the component is destroyed', () => {
+        /// @case
+        /// 1. A component owns a pending coroutine.
+        /// 2. The component is destroyed.
+        /// @expect
+        /// Destroying the component immediately stops the coroutine and runs cleanup.
+        const { component } = createProbe();
+        const events: string[] = [];
+
+        component.runCoroutine((function* (): CoroutineIterator {
+            try {
+                events.push('start');
+                yield waitUntil((): boolean => false);
+            } finally {
+                events.push('cleanup');
+            }
+        })());
+
+        component.destroy();
+
+        expect(events).toEqual(['start', 'cleanup']);
+    });
+
+    it('stops every coroutine when a cleanup stops another coroutine during stop all', () => {
+        /// @case
+        /// 1. A component starts several waiting coroutines.
+        /// 2. stopAllCoroutines runs cleanup, and one cleanup stops another coroutine handle.
+        /// @expect
+        /// Stop-all remains stable, no error is thrown, and every original coroutine is cleaned up once.
+        const { component } = createProbe();
+        const events: string[] = [];
+        let secondHandle: Coroutine | undefined;
+
+        component.runCoroutine((function* (): CoroutineIterator {
+            try {
+                events.push('first-start');
+                yield waitUntil((): boolean => false);
+            } finally {
+                events.push('first-cleanup');
+                if (secondHandle) {
+                    component.stopCoroutineHandle(secondHandle);
+                }
+                events.push('first-after-stop-second');
+            }
+        })());
+        secondHandle = component.runCoroutine((function* (): CoroutineIterator {
+            try {
+                events.push('second-start');
+                yield waitUntil((): boolean => false);
+            } finally {
+                events.push('second-cleanup');
+            }
+        })());
+        component.runCoroutine((function* (): CoroutineIterator {
+            try {
+                events.push('third-start');
+                yield waitUntil((): boolean => false);
+            } finally {
+                events.push('third-cleanup');
+            }
+        })());
+
+        expect(events).toEqual(['first-start', 'second-start', 'third-start']);
+
+        expect(() => {
+            component.stopAllCoroutineHandles();
+        }).not.toThrow();
+        expect(events).toEqual([
+            'first-start',
+            'second-start',
+            'third-start',
+            'first-cleanup',
+            'second-cleanup',
+            'first-after-stop-second',
+            'third-cleanup',
+        ]);
+    });
+    it('stops an explicit coroutine handle without resuming it later', () => {
+        /// @case
+        /// 1. A component starts a pending coroutine and stores its handle.
+        /// 2. The component stops that handle before the next tick.
+        /// @expect
+        /// The coroutine cleanup runs immediately and no later frame resumes the stopped coroutine.
+        const { component } = createProbe();
+        const events: string[] = [];
+
+        const handle = component.runCoroutine((function* (): CoroutineIterator {
+            try {
+                events.push('start');
+                yield nextFrame();
+                events.push('unreachable');
+            } finally {
+                events.push('cleanup');
+            }
+        })());
+
+        component.stopCoroutineHandle(handle);
+        director.tick(0.1);
+
+        expect(events).toEqual(['start', 'cleanup']);
+    });
+
+    it('keeps replacement coroutines started during stop-all cleanup scheduled for the next frame', () => {
+        /// @case
+        /// 1. A component stops all coroutines while a coroutine cleanup starts a replacement coroutine.
+        /// 2. The replacement coroutine yields until the next frame.
+        /// @expect
+        /// The original coroutine is stopped, the replacement starts immediately, and the replacement resumes on the next tick.
+        const { component } = createProbe();
+        const events: string[] = [];
+
+        component.runCoroutine((function* (): CoroutineIterator {
+            try {
+                events.push('original-start');
+                yield waitUntil((): boolean => false);
+            } finally {
+                events.push('original-cleanup');
+                component.runCoroutine((function* (): CoroutineIterator {
+                    events.push('replacement-start');
+                    yield nextFrame();
+                    events.push('replacement-resume');
+                })());
+            }
+        })());
+
+        component.stopAllCoroutineHandles();
+        expect(events).toEqual(['original-start', 'original-cleanup', 'replacement-start']);
+
+        director.tick(0.1);
+        expect(events).toEqual(['original-start', 'original-cleanup', 'replacement-start', 'replacement-resume']);
+    });
+});
+
+function createProbe (name = 'component-coroutine-probe'): { component: CoroutineProbe; node: Node } {
+    if (!scene) {
+        scene = new Scene('component-coroutine-test');
+        director.runSceneImmediate(scene);
+    }
+
+    const node = new Node(name);
+    const component = node.addComponent(CoroutineProbe)!;
+    scene.addChild(node);
+
+    return {
+        component,
+        node,
+    };
+}


### PR DESCRIPTION
Re: #

### Changelog

* Add component coroutine support.

-------

### Motivation

Many gameplay and UI component flows are naturally sequential, but they often need to span multiple frames: wait for an animation to finish, delay for a short amount of time, poll for a condition, then continue with the next step. Without a component-owned coroutine mechanism, those flows have to be rewritten as explicit state machines spread across component fields and `update()`.

For example, a simple enemy spawn warning flow can become bookkeeping-heavy:

```ts
enum SpawnState {
    Idle,
    ShowingWarning,
    WaitingForSpawn,
    Spawning,
    Done,
}

class EnemySpawner extends Component {
    private _state = SpawnState.Idle;
    private _elapsed = 0;
    private _warningReady = false;

    public beginSpawn (): void {
        this._state = SpawnState.ShowingWarning;
        this._elapsed = 0;
        this._warningReady = false;
        this.showWarningEffect(() => {
            this._warningReady = true;
        });
    }

    public update (dt: number): void {
        switch (this._state) {
        case SpawnState.ShowingWarning:
            if (!this._warningReady) {
                return;
            }
            this._state = SpawnState.WaitingForSpawn;
            this._elapsed = 0;
            return;
        case SpawnState.WaitingForSpawn:
            this._elapsed += dt;
            if (this._elapsed < 0.5) {
                return;
            }
            this._state = SpawnState.Spawning;
            this.spawnEnemy();
            this._state = SpawnState.Done;
            return;
        }
    }
}
```

The real intent is linear: show the warning, wait until it is ready, wait half a second, then spawn. Coroutines let component authors express that intent directly while still running on the engine frame loop:

```ts
class EnemySpawner extends Component {
    public beginSpawn (): void {
        this.startCoroutine(this.spawnFlow());
    }

    private *spawnFlow (): CoroutineIterator {
        this.showWarningEffect();
        yield waitUntil(() => this.warningReady);
        yield waitFor(0.5);
        this.spawnEnemy();
    }
}
```

This PR adds that missing component-level control-flow primitive with Unity-style timing: coroutine continuations resume after component `update()` callbacks and before later frame phases.

### Usage

Components can start a generator-based coroutine directly:

```ts
class LoadingPanel extends Component {
    protected onLoad (): void {
        this.startCoroutine(this.playIntro());
    }

    private *playIntro (): CoroutineIterator {
        this.fadeIn();
        yield waitFor(0.25);
        yield waitUntil(() => this.assetsReady);
        yield null;
        this.showReadyState();
    }
}
```

`startCoroutine()` returns a `Coroutine` handle. The handle can be passed to `stopCoroutine(handle)`, while `stopAllCoroutines()` stops every coroutine owned by the component. Supported waits include:

```ts
yield null;
yield undefined;
yield nextFrame();
yield waitFor(seconds);
yield waitUntil(predicate);
yield waitWhile(predicate);
```

### Details

* `startCoroutine()` runs synchronously until the first yield, so any work before that first yield happens immediately in the caller's stack.
* `yield null`, `yield undefined`, and `yield nextFrame()` resume during the coroutine phase no earlier than the next frame.
* The coroutine phase runs after all component `update()` callbacks, before director systems update, and before component `lateUpdate()` callbacks.
* Coroutines use the same execution-order grouping as component updates, so components with lower execution order resume before components with higher execution order.
* Coroutines started during `update()` or during another coroutine continuation are queued for a later coroutine phase and do not resume in the same frame.
* `waitFor(seconds)` resumes after enough frame `dt` has accumulated. `waitUntil(predicate)` resumes when the predicate becomes true. `waitWhile(predicate)` resumes when the predicate becomes false.
* Setting `component.enabled = false` does not pause or stop coroutines owned by that component.
* Setting `node.active = false` stops coroutines owned by affected components. Component destruction also stops owned coroutines.
* `stopCoroutine(handle)`, `stopAllCoroutines()`, and an aborted signal stop coroutines and run generator cleanup, including `finally` blocks.
* Stopping a later coroutine while the coroutine phase is iterating skips it cleanly, and `stopAllCoroutines()` is safe to call from inside a coroutine continuation or cleanup.

### Implementation

* Adds `cocos/scene-graph/component-coroutine.ts` with public coroutine types and helper instructions.
* Extends `cc.Component` with protected `startCoroutine()`, `stopCoroutine()`, and `stopAllCoroutines()` methods.
* Adds a coroutine scheduler phase immediately after component `update()` and before director systems update.
* Reuses component execution-order grouping and deferred mutation behavior, so coroutines started during update or coroutine execution cannot resume in the same frame.
* Stops component-owned coroutines when the component is destroyed or when its node becomes inactive.

### Tests

Added `tests/scene-graph/component-coroutine.test.ts` covering the behavior above, including lifecycle, ordering, waits, generator cleanup, and mutation safety.

Verified with:

* `npx jest tests/scene-graph/component-coroutine.test.ts --runInBand`
* `npm run test`

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [x] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.
