### PR TITLE
fix(aces): make HDR max value configurable via CC_ACES_HDR_MAX

### DIFF
--- a/editor/assets/chunks/common/color/aces.chunk
+++ b/editor/assets/chunks/common/color/aces.chunk
@@ -1,6 +1,10 @@
 
+#ifndef CC_ACES_HDR_MAX
+  #define CC_ACES_HDR_MAX 8.0
+#endif
+
 vec3 ACESToneMap (vec3 color) {
-  color = min(color, vec3(8.0)); // guard against overflow
+  color = min(color, vec3(CC_ACES_HDR_MAX)); // guard against overflow
   const float A = 2.51;
   const float B = 0.03;
   const float C = 2.43;


### PR DESCRIPTION
## Problem

The ACES tone mapping function in  hardcodes a clamp at  to guard against overflow. This is overly conservative:
- The ACES formula  asymptotes to ~1.033 for any input value
- There is no genuine floating-point overflow risk for any practical HDR range
- Custom pipelines can produce legitimate HDR values > 8.0, but the hardcoded clamp silently cuts them off

## Root Cause

 is a hardcoded literal with no way to override. Users with custom tone mapping or HDR pipelines are forced to accept this arbitrary limit.

## Fix

Replace the hardcoded  with a configurable macro :



- **Backward compatible**: defaults to 8.0 when  is not defined
- **Customizable**: users can  (or any value) before including the aces chunk
- **Consistent**: follows the existing / pattern used in other chunks (e.g., )

## Reproduce Conditions

1. Create a custom render pipeline that produces HDR values > 8.0
2. Apply ACES tone mapping via  in 
3. Observe that HDR values are clipped at 8.0 before tone mapping is applied

## Changelog

- : Replace hardcoded  with  macro

Fixes: #168