### PR TITLE
fix(standard): V8 crash in app shutdown

### DIFF
--- a/native/cocos/bindings/manual/jsb_module_register.cpp
+++ b/native/cocos/bindings/manual/jsb_module_register.cpp
@@ -146,12 +146,19 @@ bool jsb_register_all_modules() {
     se::ScriptEngine *se = se::ScriptEngine::getInstance();
 
     se->addBeforeCleanupHook([]() {
+#if (CC_PLATFORM == CC_PLATFORM_IOS || CC_PLATFORM == CC_PLATFORM_MACOS || CC_PLATFORM == CC_PLATFORM_ANDROID || CC_PLATFORM == CC_PLATFORM_OHOS)
         // REMOVED: se->garbageCollect()
         // Reason: Calling GC before Object::cleanup() causes MarkCompact to traverse
         // live JSTypedArrays whose external BackingStore data has already been freed
         // by AudioEngine::end(). The safe GC in ScriptEngine::cleanup() (step 5,
         // after Object::cleanup() releases all persistent handles) is sufficient.
         cc::DeferredReleasePool::clear();
+#else
+        se->garbageCollect();
+        cc::DeferredReleasePool::clear();
+        se->garbageCollect();
+        cc::DeferredReleasePool::clear();
+#endif // (CC_PLATFORM == CC_PLATFORM_IOS || CC_PLATFORM == CC_PLATFORM_MACOS || CC_PLATFORM == CC_PLATFORM_ANDROID || CC_PLATFORM == CC_PLATFORM_OHOS)
     });
 
     se->addRegisterCallback(jsb_register_global_variables);

--- a/native/cocos/bindings/manual/jsb_module_register.cpp
+++ b/native/cocos/bindings/manual/jsb_module_register.cpp
@@ -145,10 +145,12 @@
 bool jsb_register_all_modules() {
     se::ScriptEngine *se = se::ScriptEngine::getInstance();
 
-    se->addBeforeCleanupHook([se]() {
-        se->garbageCollect();
-        cc::DeferredReleasePool::clear();
-        se->garbageCollect();
+    se->addBeforeCleanupHook([]() {
+        // REMOVED: se->garbageCollect()
+        // Reason: Calling GC before Object::cleanup() causes MarkCompact to traverse
+        // live JSTypedArrays whose external BackingStore data has already been freed
+        // by AudioEngine::end(). The safe GC in ScriptEngine::cleanup() (step 5,
+        // after Object::cleanup() releases all persistent handles) is sufficient.
         cc::DeferredReleasePool::clear();
     });
 

--- a/native/cocos/bindings/manual/jsb_module_register.cpp
+++ b/native/cocos/bindings/manual/jsb_module_register.cpp
@@ -145,7 +145,7 @@
 bool jsb_register_all_modules() {
     se::ScriptEngine *se = se::ScriptEngine::getInstance();
 
-    se->addBeforeCleanupHook([]() {
+    se->addBeforeCleanupHook([se]() {
 #if (CC_PLATFORM == CC_PLATFORM_IOS || CC_PLATFORM == CC_PLATFORM_MACOS || CC_PLATFORM == CC_PLATFORM_ANDROID || CC_PLATFORM == CC_PLATFORM_OHOS)
         // REMOVED: se->garbageCollect()
         // Reason: Calling GC before Object::cleanup() causes MarkCompact to traverse


### PR DESCRIPTION
Re: #

### Changelog

* Calling GC before Object::cleanup() causes MarkCompact to traverse
        live JSTypedArrays whose external BackingStore data has already been freed
        by AudioEngine::end(). The safe GC in ScriptEngine::cleanup() (step 5,
        after Object::cleanup() releases all persistent handles) is sufficient.
* https://github.com/cocos/cocos-engine/issues/19177

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
