### PR TITLE
feat(spine): support runtime-selectable spine version for editor/preview

### DIFF
--- a/cc.config.json
+++ b/cc.config.json
@@ -470,7 +470,15 @@
             }
         },
         {
-            "test": "context.buildTimeConstants.SPINE_3_8",
+            "test": "context.buildTimeConstants.SPINE_3_8 && context.buildTimeConstants.SPINE_4_2",
+            "isVirtualModule": false,
+            "overrides": {
+                "cocos/spine/lib/spine-version.ts": "cocos/spine/lib/spine-version-dynamic.ts",
+                "cocos/spine/lib/spine-instantiate.ts": "cocos/spine/lib/spine-instantiate-dynamic.ts"
+            }
+        },
+        {
+            "test": "context.buildTimeConstants.SPINE_3_8 && !context.buildTimeConstants.SPINE_4_2",
             "isVirtualModule": false,
             "overrides": {
                 "cocos/spine/lib/spine-version.ts": "cocos/spine/lib/spine-version-3.8.ts",
@@ -478,7 +486,7 @@
             }
         },
         {
-            "test": "context.buildTimeConstants.SPINE_4_2",
+            "test": "context.buildTimeConstants.SPINE_4_2 && !context.buildTimeConstants.SPINE_3_8",
             "isVirtualModule": false,
             "overrides": {
                 "cocos/spine/lib/spine-version.ts": "cocos/spine/lib/spine-version-4.2.ts",

--- a/cocos/spine/lib/spine-instantiate-dynamic.ts
+++ b/cocos/spine/lib/spine-instantiate-dynamic.ts
@@ -1,0 +1,90 @@
+/*
+ Copyright (c) 2025 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+// Runtime-selectable spine instantiation. Used only when both spine-3.8 and spine-4.2 are compiled into
+// the engine (editor/preview): cc.config.json's moduleOverrides then replaces spine-instantiate.ts with
+// this file. Unlike the fixed-version files (spine-instantiate-3.8.ts / -4.2.ts), both the 3.8 and 4.2
+// external references are kept here (so both wasm/asm binaries are bundled), and the matching one is
+// executed at runtime according to the selected version.
+// The version comes from the preview boot (game-boot.js / engine-bootstrap.ts), which reads it from
+// cocos.config.json before engine init and writes globalThis._CC_SPINE_VERSION.
+
+import { ensureWasmModuleReady } from 'pal/wasm';
+import { error } from '../../core';
+import { shouldUseWasmModule, initWasm, initAsmJS } from './spine-wasm-utils';
+// Import setSpineVersion through the overridden './spine-version' (= spine-version-dynamic) so it is the
+// same module instance whose SPINE_VERSION live binding is read by the shared spine-define.ts.
+import { setSpineVersion } from './spine-version';
+
+function getSelectedSpineVersion (): string {
+    const v = (globalThis as any)._CC_SPINE_VERSION;
+    return v === '4.2' ? '4.2' : '3.8';
+}
+
+export function waitForSpineWasmInstantiation (): Promise<void> {
+    const errorReport = (msg: any): void => { error(msg); };
+    // The version must be set before wasm instantiation and before spine-define patches prototypes.
+    const version = getSelectedSpineVersion();
+    setSpineVersion(version);
+    return ensureWasmModuleReady().then((): Promise<void> => {
+        //We should use static code here, import operation will cause file copy to cache folder.
+        if (version === '4.2') {
+            if (shouldUseWasmModule()) {
+                return Promise.all([
+                    import('external:emscripten/spine/4.2/spine.wasm.js'),
+                    import('external:emscripten/spine/4.2/spine.wasm'),
+                ]).then(([
+                    { default: wasmFactory },
+                    { default: spineWasmUrl },
+                ]) => initWasm(wasmFactory, spineWasmUrl));
+            } else {
+                return Promise.all([
+                    import('external:emscripten/spine/4.2/spine.asm.js'),
+                    import('external:emscripten/spine/4.2/spine.js.mem'),
+                ]).then(([
+                    { default: asmFactory },
+                    { default: asmJsMemUrl },
+                ]) => initAsmJS(asmFactory, asmJsMemUrl));
+            }
+        } else {
+            if (shouldUseWasmModule()) {
+                return Promise.all([
+                    import('external:emscripten/spine/3.8/spine.wasm.js'),
+                    import('external:emscripten/spine/3.8/spine.wasm'),
+                ]).then(([
+                    { default: wasmFactory },
+                    { default: spineWasmUrl },
+                ]) => initWasm(wasmFactory, spineWasmUrl));
+            } else {
+                return Promise.all([
+                    import('external:emscripten/spine/3.8/spine.asm.js'),
+                    import('external:emscripten/spine/3.8/spine.js.mem'),
+                ]).then(([
+                    { default: asmFactory },
+                    { default: asmJsMemUrl },
+                ]) => initAsmJS(asmFactory, asmJsMemUrl));
+            }
+        }
+    }).catch(errorReport);
+}

--- a/cocos/spine/lib/spine-version-dynamic.ts
+++ b/cocos/spine/lib/spine-version-dynamic.ts
@@ -1,0 +1,88 @@
+/*
+ Copyright (c) 2025 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+// Runtime-selectable spine version. Used only when both spine-3.8 and spine-4.2 are compiled into the
+// engine (editor/preview): cc.config.json's moduleOverrides then replaces spine-version.ts with this file.
+// Unlike the fixed-version files (spine-version-3.8.ts / -4.2.ts), SPINE_VERSION is a mutable `let`
+// (a live ES binding), so the shared layer (spine-define.ts / skeleton.ts) reads the runtime value and
+// keeps both `SPINE_VERSION === '3.8' / '4.2'` branches instead of tree-shaking to a single one.
+// The version is set by spine-instantiate-dynamic.ts before instantiation, sourced from the host-provided
+// globalThis._CC_SPINE_VERSION (injected by the preview boot from cocos.config.json).
+import { DataInput, SkeletonBinary } from './spine-binary';
+import { BUILD } from 'internal:constants';
+
+// Typed as string so comparisons in the shared layer against the other version literal are not flagged by TS.
+export let SPINE_VERSION: string = '3.8';
+
+/**
+ * Sets the current spine version. Must be called before spine wasm instantiation and before spine-define runs.
+ */
+export function setSpineVersion (version: string): void {
+    SPINE_VERSION = version === '4.2' ? '4.2' : '3.8';
+}
+
+function isVersionCompatible (version: string | null): boolean {
+    if (!BUILD) {
+        if (SPINE_VERSION === '3.8') {
+            if (!version || version === '3.8.75' || !version.startsWith('3.8.')) {
+                return false;
+            }
+        } else {
+            if (!version || !version.startsWith('4.2.')) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+/**
+ * @internal Used only by editor.
+ */
+export function isBinaryCompatible (buffer: Uint8Array): boolean {
+    if (!BUILD) {
+        const input = new DataInput(buffer);
+        // The binary hash header differs between versions: 3.8 uses one string, 4.2 uses two ints.
+        if (SPINE_VERSION === '3.8') {
+            SkeletonBinary.readString(input); // read hash
+        } else {
+            SkeletonBinary.readInt(input); // read hash
+            SkeletonBinary.readInt(input); // read hash
+        }
+        const version = SkeletonBinary.readString(input);
+
+        return isVersionCompatible(version);
+    }
+    return false;
+}
+
+/**
+ * @internal Used only by editor.
+ */
+export function isJsonCompatible (json: JSON): boolean {
+    if (!BUILD) {
+        return isVersionCompatible(json['skeleton']['spine']);
+    }
+    return false;
+}

--- a/cocos/spine/lib/spine-version.ts
+++ b/cocos/spine/lib/spine-version.ts
@@ -24,6 +24,12 @@
 
 export const SPINE_VERSION = '3.8';
 
+// Placeholder so spine-instantiate-dynamic.ts can import setSpineVersion from './spine-version' and type-check.
+// When building the engine with runtime-selectable spine, moduleOverrides replaces this file with
+// spine-version-dynamic.ts (the real implementation). In fixed single-version builds (spine-3.8 / spine-4.2)
+// spine-instantiate-dynamic is not used, so this no-op is never called.
+export function setSpineVersion (version: string): void {}
+
 export function isBinaryCompatible (buffer: Uint8Array): boolean {
     return false;
 }


### PR DESCRIPTION
## Summary

Compile both `spine-3.8` and `spine-4.2` into the editor/preview engine and select the active version at runtime, so the scene editor and browser preview can switch spine versions from the project config without rebuilding the engine.

## Why

The editor/preview engine is a single prebuilt full engine, so the spine version was fixed at compile time and could not follow the project's `includeModules` selection. Only `spine-version.ts` and `spine-instantiate.ts` are version-specific — the JS wrapper layer (`spine-define.ts` / `spine-core.js` / `skeleton.ts`) is shared between versions — which makes a runtime selector feasible.

## Changes

- **`spine-version-dynamic.ts`** (new): `SPINE_VERSION` exported as a mutable live binding plus `setSpineVersion()`; binary/json compatibility checks dispatch by the current version. Using `let` keeps both branches in the shared layer instead of tree-shaking to a single one.
- **`spine-instantiate-dynamic.ts`** (new): loads the matching spine wasm/asm at runtime according to the selected version; both external references are kept so both binaries are bundled.
- **`spine-version.ts`**: adds a `setSpineVersion` placeholder for type checking (replaced by the dynamic variant through `moduleOverrides` when both versions are compiled).
- **`cc.config.json`**: adds a dynamic `moduleOverride` rule (`SPINE_3_8 && SPINE_4_2` → the dynamic files) and makes the existing single-version rules mutually exclusive.

## Impact

- **Single-version builds are unchanged**: only one `SPINE_*` constant is true, so the dynamic rule never fires and a single wasm is bundled — no package-size impact.
- The active version is provided by the host before engine initialization (via `globalThis._CC_SPINE_VERSION`), driven by the cli side, which compiles both versions into the dev-cli engine and injects the selection from the project config.
