### PR TITLE
fix(standard): In jsb mode, retrieving a node property may result in …

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -3980,3 +3980,7 @@ Debug bones or slots is invalid in cached mode.
 ### 16419
 
 Spine version not supported.
+
+### 16420
+
+This node has no shared buffer, Please check if it is initialized properly.

--- a/cocos/scene-graph/node.jsb.ts
+++ b/cocos/scene-graph/node.jsb.ts
@@ -1053,6 +1053,10 @@ Object.defineProperty(nodeProto, 'activeInHierarchy', {
     configurable: true,
     enumerable: true,
     get(): Readonly<Boolean> {
+        if (this._sharedUint8Arr.buffer.byteLength === 0) {
+            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            return false;
+        }
         return (this._sharedUint8Arr[0] & 0x01) !== 0; // Uint8, 0:0, activeInHierarchy
     },
     set(v) {
@@ -1064,6 +1068,10 @@ Object.defineProperty(nodeProto, '_activeInHierarchy', {
     configurable: true,
     enumerable: true,
     get(): Readonly<Boolean> {
+        if (this._sharedUint8Arr.buffer.byteLength === 0) {
+            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            return false;
+        }
         return (this._sharedUint8Arr[0] & 0x01) !== 0; // Uint8, 0:0, activeInHierarchy
     },
     set(v) {
@@ -1075,6 +1083,10 @@ Object.defineProperty(nodeProto, 'layer', {
     configurable: true,
     enumerable: true,
     get() {
+        if (this._sharedUint32Arr.buffer.byteLength === 0) {
+            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            return 0;
+        }
         return this._sharedUint32Arr[1]; // Uint32, 1: layer
     },
     set(v) {
@@ -1091,6 +1103,10 @@ Object.defineProperty(nodeProto, '_layer', {
     configurable: true,
     enumerable: true,
     get() {
+        if (this._sharedUint32Arr.buffer.byteLength === 0) {
+            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            return 0;
+        }
         return this._sharedUint32Arr[1]; // Uint32, 1: layer
     },
     set(v) {
@@ -1102,6 +1118,10 @@ Object.defineProperty(nodeProto, '_eventMask', {
     configurable: true,
     enumerable: true,
     get() {
+        if (this._sharedUint32Arr.buffer.byteLength === 0) {
+            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            return 0;
+        }
         return this._sharedUint32Arr[0]; // Uint32, 0: eventMask
     },
     set(v) {
@@ -1113,6 +1133,10 @@ Object.defineProperty(nodeProto, '_siblingIndex', {
     configurable: true,
     enumerable: true,
     get() {
+        if (this._sharedInt32Arr.buffer.byteLength === 0) {
+            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            return 0;
+        }
         return this._sharedInt32Arr[0]; // Int32, 0: siblingIndex
     },
     set(v) {
@@ -1133,6 +1157,10 @@ Object.defineProperty(nodeProto, 'siblingIndex', {
     configurable: true,
     enumerable: true,
     get() {
+        if (this._sharedInt32Arr.buffer.byteLength === 0) {
+            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            return 0;
+        }
         return this._sharedInt32Arr[0]; // Int32, 0: siblingIndex
     },
     set(v) {
@@ -1142,6 +1170,10 @@ Object.defineProperty(nodeProto, 'siblingIndex', {
 
 // note: setSiblingIndex is a JSB function, DO NOT override it
 nodeProto.getSiblingIndex = function getSiblingIndex() {
+    if (this._sharedInt32Arr.buffer.byteLength === 0) {
+        console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+        return 0;
+    }
     return this._sharedInt32Arr[0]; // Int32, 0: siblingIndex
 };
 
@@ -1150,6 +1182,10 @@ Object.defineProperty(nodeProto, '_transformFlags', {
     configurable: true,
     enumerable: true,
     get() {
+        if (this._sharedUint32Arr.buffer.byteLength === 0) {
+            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            return 0;
+        }
         return this._sharedUint32Arr[2]; // Uint32, 2: _transformFlags
     },
     set(v) {
@@ -1161,6 +1197,10 @@ Object.defineProperty(nodeProto, '_active', {
     configurable: true,
     enumerable: true,
     get(): Readonly<Boolean> {
+        if (this._sharedUint8Arr.buffer.byteLength === 0) {
+            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            return false;
+        }
         return (this._sharedUint8Arr[0] & 0x02) !== 0; // Uint8, 0:1, active
     },
     set(v) {
@@ -1172,6 +1212,10 @@ Object.defineProperty(nodeProto, 'active', {
     configurable: true,
     enumerable: true,
     get(): Readonly<Boolean> {
+        if (this._sharedUint8Arr.buffer.byteLength === 0) {
+            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            return false;
+        }
         return (this._sharedUint8Arr[0] & 0x02) !== 0; // Uint8, 0:1, active
     },
     set(v) {
@@ -1183,6 +1227,10 @@ Object.defineProperty(nodeProto, '_static', {
     configurable: true,
     enumerable: true,
     get(): Readonly<Boolean> {
+        if (this._sharedUint8Arr.buffer.byteLength === 0) {
+            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            return false;
+        }
         return (this._sharedUint8Arr[0] & 0x04) !== 0; // Uint8, 0:2, static
     },
     set(v) {
@@ -1194,6 +1242,10 @@ Object.defineProperty(nodeProto, '_colorDirty', {
     configurable: true,
     enumerable: true,
     get(): Readonly<Boolean> {
+        if (this._sharedUint8Arr.buffer.byteLength === 0) {
+            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            return false;
+        }
         return (this._sharedUint8Arr[0] & 0x08) !== 0; // Uint8, 0:3, _colorDirty
     },
     set(v) {
@@ -1205,6 +1257,10 @@ Object.defineProperty(nodeProto, '_skewType', {
     configurable: true,
     enumerable: true,
     get(): number {
+        if (this._sharedUint8Arr.buffer.byteLength === 0) {
+            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            return 0;
+        }
         return this._sharedUint8Arr[1];
     },
     set(v) {
@@ -1507,36 +1563,52 @@ nodeProto._setSkew = function (v: IVec2Like): void {
 };
 
 nodeProto._getSkewX = function () {
+    if (this._sharedFloat32Arr.buffer.byteLength === 0) {
+        console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+        return 0;
+    }
     return this._sharedFloat32Arr[0];
 };
 
 nodeProto._setSkewX = function (v: number) {
     this._sharedFloat32Arr[0] = v;
-}
+};
 
 nodeProto._getSkewY = function () {
+    if (this._sharedFloat32Arr.buffer.byteLength === 0) {
+        console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+        return 0;
+    }
     return this._sharedFloat32Arr[1];
 };
 
 nodeProto._setSkewY = function (v: number) {
     this._sharedFloat32Arr[1] = v;
-}
+};
 
 nodeProto._getLocalOpacity = function (): number {
+    if (this._sharedFloat32Arr.buffer.byteLength === 0) {
+        console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+        return 1;
+    }
     return this._sharedFloat32Arr[2];
 };
 
 nodeProto._setLocalOpacity = function (v: number): void {
     this._sharedFloat32Arr[2] = v;
-}
+}; 
 
 nodeProto._getFinalOpacity = function (): number {
+    if (this._sharedFloat32Arr.buffer.byteLength === 0) {
+        console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+        return 1;
+    }
     return this._sharedFloat32Arr[3];
 };
 
 nodeProto._setFinalOpacity = function (v: number): void {
     this._sharedFloat32Arr[3] = v;
-}
+};
 
 //
 nodeProto._ctor = function (name?: string) {

--- a/cocos/scene-graph/node.jsb.ts
+++ b/cocos/scene-graph/node.jsb.ts
@@ -22,7 +22,7 @@
 
 import { EDITOR, EDITOR_NOT_IN_PREVIEW } from 'internal:constants';
 import { cclegacy } from '../core/global-exports';
-import { errorID, getError } from '../core/platform/debug';
+import { errorID, getError, warnID } from '../core/platform/debug';
 import { Component } from './component';
 import { NodeEventType } from './node-event';
 import { CCObjectFlags } from '../core/data/object';
@@ -1054,7 +1054,7 @@ Object.defineProperty(nodeProto, 'activeInHierarchy', {
     enumerable: true,
     get(): Readonly<Boolean> {
         if (this._sharedUint8Arr.buffer.byteLength === 0) {
-            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            warnID(16420, `Node ${this.name}`);
             return false;
         }
         return (this._sharedUint8Arr[0] & 0x01) !== 0; // Uint8, 0:0, activeInHierarchy
@@ -1069,7 +1069,7 @@ Object.defineProperty(nodeProto, '_activeInHierarchy', {
     enumerable: true,
     get(): Readonly<Boolean> {
         if (this._sharedUint8Arr.buffer.byteLength === 0) {
-            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            warnID(16420, `Node ${this.name}`);
             return false;
         }
         return (this._sharedUint8Arr[0] & 0x01) !== 0; // Uint8, 0:0, activeInHierarchy
@@ -1084,7 +1084,7 @@ Object.defineProperty(nodeProto, 'layer', {
     enumerable: true,
     get() {
         if (this._sharedUint32Arr.buffer.byteLength === 0) {
-            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            warnID(16420, `Node ${this.name}`);
             return 0;
         }
         return this._sharedUint32Arr[1]; // Uint32, 1: layer
@@ -1104,7 +1104,7 @@ Object.defineProperty(nodeProto, '_layer', {
     enumerable: true,
     get() {
         if (this._sharedUint32Arr.buffer.byteLength === 0) {
-            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            warnID(16420, `Node ${this.name}`);
             return 0;
         }
         return this._sharedUint32Arr[1]; // Uint32, 1: layer
@@ -1119,7 +1119,7 @@ Object.defineProperty(nodeProto, '_eventMask', {
     enumerable: true,
     get() {
         if (this._sharedUint32Arr.buffer.byteLength === 0) {
-            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            warnID(16420, `Node ${this.name}`);
             return 0;
         }
         return this._sharedUint32Arr[0]; // Uint32, 0: eventMask
@@ -1134,7 +1134,7 @@ Object.defineProperty(nodeProto, '_siblingIndex', {
     enumerable: true,
     get() {
         if (this._sharedInt32Arr.buffer.byteLength === 0) {
-            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            warnID(16420, `Node ${this.name}`);
             return 0;
         }
         return this._sharedInt32Arr[0]; // Int32, 0: siblingIndex
@@ -1158,7 +1158,7 @@ Object.defineProperty(nodeProto, 'siblingIndex', {
     enumerable: true,
     get() {
         if (this._sharedInt32Arr.buffer.byteLength === 0) {
-            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            warnID(16420, `Node ${this.name}`);
             return 0;
         }
         return this._sharedInt32Arr[0]; // Int32, 0: siblingIndex
@@ -1171,7 +1171,7 @@ Object.defineProperty(nodeProto, 'siblingIndex', {
 // note: setSiblingIndex is a JSB function, DO NOT override it
 nodeProto.getSiblingIndex = function getSiblingIndex() {
     if (this._sharedInt32Arr.buffer.byteLength === 0) {
-        console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+        warnID(16420, `Node ${this.name}`);
         return 0;
     }
     return this._sharedInt32Arr[0]; // Int32, 0: siblingIndex
@@ -1183,7 +1183,7 @@ Object.defineProperty(nodeProto, '_transformFlags', {
     enumerable: true,
     get() {
         if (this._sharedUint32Arr.buffer.byteLength === 0) {
-            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            warnID(16420, `Node ${this.name}`);
             return 0;
         }
         return this._sharedUint32Arr[2]; // Uint32, 2: _transformFlags
@@ -1198,7 +1198,7 @@ Object.defineProperty(nodeProto, '_active', {
     enumerable: true,
     get(): Readonly<Boolean> {
         if (this._sharedUint8Arr.buffer.byteLength === 0) {
-            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            warnID(16420, `Node ${this.name}`);
             return false;
         }
         return (this._sharedUint8Arr[0] & 0x02) !== 0; // Uint8, 0:1, active
@@ -1213,7 +1213,7 @@ Object.defineProperty(nodeProto, 'active', {
     enumerable: true,
     get(): Readonly<Boolean> {
         if (this._sharedUint8Arr.buffer.byteLength === 0) {
-            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            warnID(16420, `Node ${this.name}`);
             return false;
         }
         return (this._sharedUint8Arr[0] & 0x02) !== 0; // Uint8, 0:1, active
@@ -1228,7 +1228,7 @@ Object.defineProperty(nodeProto, '_static', {
     enumerable: true,
     get(): Readonly<Boolean> {
         if (this._sharedUint8Arr.buffer.byteLength === 0) {
-            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            warnID(16420, `Node ${this.name}`);
             return false;
         }
         return (this._sharedUint8Arr[0] & 0x04) !== 0; // Uint8, 0:2, static
@@ -1243,7 +1243,7 @@ Object.defineProperty(nodeProto, '_colorDirty', {
     enumerable: true,
     get(): Readonly<Boolean> {
         if (this._sharedUint8Arr.buffer.byteLength === 0) {
-            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            warnID(16420, `Node ${this.name}`);
             return false;
         }
         return (this._sharedUint8Arr[0] & 0x08) !== 0; // Uint8, 0:3, _colorDirty
@@ -1258,7 +1258,7 @@ Object.defineProperty(nodeProto, '_skewType', {
     enumerable: true,
     get(): number {
         if (this._sharedUint8Arr.buffer.byteLength === 0) {
-            console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+            warnID(16420, `Node ${this.name}`);
             return 0;
         }
         return this._sharedUint8Arr[1];
@@ -1564,7 +1564,7 @@ nodeProto._setSkew = function (v: IVec2Like): void {
 
 nodeProto._getSkewX = function () {
     if (this._sharedFloat32Arr.buffer.byteLength === 0) {
-        console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+        warnID(16420, `Node ${this.name}`);
         return 0;
     }
     return this._sharedFloat32Arr[0];
@@ -1576,7 +1576,7 @@ nodeProto._setSkewX = function (v: number) {
 
 nodeProto._getSkewY = function () {
     if (this._sharedFloat32Arr.buffer.byteLength === 0) {
-        console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+        warnID(16420, `Node ${this.name}`);
         return 0;
     }
     return this._sharedFloat32Arr[1];
@@ -1588,7 +1588,7 @@ nodeProto._setSkewY = function (v: number) {
 
 nodeProto._getLocalOpacity = function (): number {
     if (this._sharedFloat32Arr.buffer.byteLength === 0) {
-        console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+        warnID(16420, `Node ${this.name}`);
         return 1;
     }
     return this._sharedFloat32Arr[2];
@@ -1600,7 +1600,7 @@ nodeProto._setLocalOpacity = function (v: number): void {
 
 nodeProto._getFinalOpacity = function (): number {
     if (this._sharedFloat32Arr.buffer.byteLength === 0) {
-        console.warn(`Node ${this.name} has no shared buffer, please check if it is initialized properly.`);
+        warnID(16420, `Node ${this.name}`);
         return 1;
     }
     return this._sharedFloat32Arr[3];


### PR DESCRIPTION
…an error

Re: #

### Changelog

* In jsb, many of a node’s properties are set via _shared_xxx_Arr, such as _siblingIndex.
As a result, when a node is destroyed, the _shared_xxx_Arr objects are all set to null, and attempting to access them again will result in an error.
The current workaround is to check whether these properties are null before accessing them.

* https://github.com/cocos/cocos-engine/issues/18907

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
