### PR TITLE
fix(standard): spelling errors

### DIFF
--- a/cocos/tiledmap/tiled-layer.ts
+++ b/cocos/tiledmap/tiled-layer.ts
@@ -878,7 +878,7 @@ export class TiledLayer extends UIRenderer {
         const axis = this._staggerAxis;
 
         switch (this._layerOrientation) {
-        // left top to right dowm
+        // left top to right down
         case Orientation.ORTHO:
             col = Math.floor(x / maptw);
             row = Math.floor(y / mapth);
@@ -889,7 +889,7 @@ export class TiledLayer extends UIRenderer {
             col = Math.floor(x / maptw2);
             row = Math.floor(y / mapth2);
             break;
-            // left top to right dowm
+            // left top to right down
         case Orientation.HEX:
             if (axis === StaggerAxis.STAGGERAXIS_Y) {
                 row = Math.floor(y / (mapth - this._diffY1!));
@@ -1017,7 +1017,7 @@ export class TiledLayer extends UIRenderer {
         }
 
         switch (layerOrientation) {
-        // left top to right dowm
+        // left top to right down
         case Orientation.ORTHO:
             cullingCol = col;
             cullingRow = rows - row - 1;
@@ -1039,7 +1039,7 @@ export class TiledLayer extends UIRenderer {
             left = maptw2 * cullingCol;
             bottom = mapth2 * cullingRow;
             break;
-            // left top to right dowm
+            // left top to right down
         case Orientation.HEX:
             diffX2 = (axis! === StaggerAxis.STAGGERAXIS_Y && row % 2 === 1) ? maptw2 * odd_even! : 0;
             diffY2 = (axis! === StaggerAxis.STAGGERAXIS_X && col % 2 === 1) ? mapth2 * -odd_even! : 0;


### PR DESCRIPTION
Re: #

### Changelog

* fix spelling errors
* https://github.com/cocos/cocos-engine/issues/18903

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [x] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
