### PR TITLE
fix(tonemap): respect CC_TONE_MAPPING_TYPE in tonemap.effect

### DIFF
--- a/editor/assets/effects/pipeline/tonemap.effect
+++ b/editor/assets/effects/pipeline/tonemap.effect
@@ -55,7 +55,9 @@ CCProgram tonemap-fs %{
   vec3 ToLDR(vec3 color) {
     #if CC_USE_HDR
       color *= cc_exposure.x * FP_SCALE_INV;
-      color = ACESToneMap(color);
+      #if CC_TONE_MAPPING_TYPE == HDR_TONE_MAPPING_ACES
+        color = ACESToneMap(color);
+      #endif
       color = LinearToSRGB(color);
     #endif
     return color;


### PR DESCRIPTION
## Problem

The `tonemap.effect` legacy path directly calls `ACESToneMap()` without checking `CC_TONE_MAPPING_TYPE`, unlike the other 3 ACES entry points (`tone-mapping.chunk`, `forward-fs.chunk`, `float-output-process.effect`) which correctly gate via:

```glsl
#if CC_TONE_MAPPING_TYPE == HDR_TONE_MAPPING_ACES
  color.rgb = ACESToneMap(color.rgb);
#endif
```

This means even when users set `toneMappingType = 1` (LINEAR / no tonemap), the `tonemap.effect` path still forces ACES tone mapping, ignoring the user's choice.

## Root Cause

`tonemap.effect:58` hardcodes the ACES call without a `CC_TONE_MAPPING_TYPE` preprocessor check. All other tone-mapping entry points already have this guard.

## Fix

Add the missing `#if CC_TONE_MAPPING_TYPE == HDR_TONE_MAPPING_ACES` check around `ACESToneMap()` in `tonemap.effect`, consistent with `tone-mapping.chunk`.

```diff
 vec3 ToLDR(vec3 color) {
   #if CC_USE_HDR
     color *= cc_exposure.x * FP_SCALE_INV;
-    color = ACESToneMap(color);
+    #if CC_TONE_MAPPING_TYPE == HDR_TONE_MAPPING_ACES
+      color = ACESToneMap(color);
+    #endif
     color = LinearToSRGB(color);
   #endif
   return color;
 }
```

- **Backward compatible**: when `CC_TONE_MAPPING_TYPE == HDR_TONE_MAPPING_ACES` (default), behavior is unchanged
- **Consistent**: matches the pattern used in `tone-mapping.chunk:13` and all other paths
- **Minimal**: single file, 3 lines added

## How Custom Pipelines Can Bypass ACES (Issue #168)

1. Set `PostSettings.toneMappingType = 1` (LINEAR) — now skips ACES in all 4 rendering paths
2. Enable `CC_USE_FLOAT_OUTPUT` — scene pass writes raw HDR to RGBA16F, bypassing inline tone mapping entirely
3. Write your own tonemap pass — custom pipelines fully control their post-processing

Fixes: #168