### PR TITLE
fix(SRP): crash when native OpenAL is unavailable

### DIFF
--- a/native/cocos/audio/AudioEngine.cpp
+++ b/native/cocos/audio/AudioEngine.cpp
@@ -60,9 +60,9 @@ namespace cc {
 const int AudioEngine::INVALID_AUDIO_ID = -1;
 const float AudioEngine::TIME_UNKNOWN = -1.0F;
 
-// audio file path,audio IDs
+//audio file path,audio IDs
 ccstd::unordered_map<ccstd::string, ccstd::list<int>> AudioEngine::sAudioPathIDMap;
-// profileName,ProfileHelper
+//profileName,ProfileHelper
 ccstd::unordered_map<ccstd::string, AudioEngine::ProfileHelper> AudioEngine::sAudioPathProfileHelperMap;
 unsigned int AudioEngine::sMaxInstances = MAX_AUDIOINSTANCES;
 AudioEngine::ProfileHelper *AudioEngine::sDefaultProfileHelper = nullptr;

--- a/native/cocos/audio/AudioEngine.cpp
+++ b/native/cocos/audio/AudioEngine.cpp
@@ -60,14 +60,17 @@ namespace cc {
 const int AudioEngine::INVALID_AUDIO_ID = -1;
 const float AudioEngine::TIME_UNKNOWN = -1.0F;
 
-//audio file path,audio IDs
+// audio file path,audio IDs
 ccstd::unordered_map<ccstd::string, ccstd::list<int>> AudioEngine::sAudioPathIDMap;
-//profileName,ProfileHelper
+// profileName,ProfileHelper
 ccstd::unordered_map<ccstd::string, AudioEngine::ProfileHelper> AudioEngine::sAudioPathProfileHelperMap;
 unsigned int AudioEngine::sMaxInstances = MAX_AUDIOINSTANCES;
 AudioEngine::ProfileHelper *AudioEngine::sDefaultProfileHelper = nullptr;
 ccstd::unordered_map<int, AudioEngine::AudioInfo> AudioEngine::sAudioIDInfoMap;
 AudioEngineImpl *AudioEngine::sAudioEngineImpl = nullptr;
+// Decoder-only fallback instance, defined here to keep AudioDecoderManager
+// initialization separate from OpenAL initialization.
+AudioEngineImpl *AudioEngine::sDecoderImpl = nullptr;
 
 float AudioEngine::sVolumeFactor = 1.0F;
 events::EnterBackground::Listener AudioEngine::sOnPauseListenerID;
@@ -155,6 +158,9 @@ void AudioEngine::end() {
 
     delete sAudioEngineImpl;
     sAudioEngineImpl = nullptr;
+
+    delete sDecoderImpl;
+    sDecoderImpl = nullptr;
 
     delete sDefaultProfileHelper;
     sDefaultProfileHelper = nullptr;
@@ -587,12 +593,28 @@ bool AudioEngine::isEnabled() {
     return sIsEnabled;
 }
 
-PCMHeader AudioEngine::getPCMHeader(const char *url) {
-    lazyInit();
-    return sAudioEngineImpl->getPCMHeader(url);
+AudioEngineImpl *AudioEngine::getDecoderImpl() {
+    if (AudioEngine::sAudioEngineImpl != nullptr) {
+        return AudioEngine::sAudioEngineImpl;
+    }
+    // Try full init first; if it succeeds we get OpenAL + decoder.
+    AudioEngine::lazyInit();
+    if (AudioEngine::sAudioEngineImpl != nullptr) {
+        return AudioEngine::sAudioEngineImpl;
+    }
+    // OpenAL unavailable — use a decoder-only fallback instance.
+    if (AudioEngine::sDecoderImpl == nullptr) {
+        AudioEngine::sDecoderImpl = ccnew AudioEngineImpl();
+        AudioEngine::sDecoderImpl->initDecoder();
+    }
+    return AudioEngine::sDecoderImpl;
 }
+
+PCMHeader AudioEngine::getPCMHeader(const char *url) {
+    return AudioEngine::getDecoderImpl()->getPCMHeader(url);
+}
+
 ccstd::vector<uint8_t> AudioEngine::getOriginalPCMBuffer(const char *url, uint32_t channelID) {
-    lazyInit();
-    return sAudioEngineImpl->getOriginalPCMBuffer(url, channelID);
+    return AudioEngine::getDecoderImpl()->getOriginalPCMBuffer(url, channelID);
 }
 } // namespace cc

--- a/native/cocos/audio/AudioEngine.cpp
+++ b/native/cocos/audio/AudioEngine.cpp
@@ -605,7 +605,7 @@ AudioEngineImpl *AudioEngine::getDecoderImpl() {
     // OpenAL unavailable — use a decoder-only fallback instance.
     if (AudioEngine::sDecoderImpl == nullptr) {
         AudioEngine::sDecoderImpl = ccnew AudioEngineImpl();
-        AudioEngine::sDecoderImpl->initDecoder();
+        AudioEngineImpl::initDecoder();
     }
     return AudioEngine::sDecoderImpl;
 }

--- a/native/cocos/audio/AudioEngine.cpp
+++ b/native/cocos/audio/AudioEngine.cpp
@@ -602,19 +602,39 @@ AudioEngineImpl *AudioEngine::getDecoderImpl() {
     if (AudioEngine::sAudioEngineImpl != nullptr) {
         return AudioEngine::sAudioEngineImpl;
     }
-    // OpenAL unavailable — use a decoder-only fallback instance.
+    // On oalsoft platforms, PCM decoding via AudioDecoderManager works
+    // independently of OpenAL — create a decoder-only fallback instance.
+    // On Android/OpenHarmony and Apple, AudioEngineImpl::getPCMHeader/
+    // getOriginalPCMBuffer dereferences _audioPlayerProvider/_engineEngine
+    // which are only set up by init(). Returning nullptr here lets callers
+    // fail gracefully instead of crashing.
+#if CC_PLATFORM == CC_PLATFORM_WINDOWS || CC_PLATFORM == CC_PLATFORM_OHOS || \
+    CC_PLATFORM == CC_PLATFORM_LINUX || CC_PLATFORM == CC_PLATFORM_QNX
     if (AudioEngine::sDecoderImpl == nullptr) {
         AudioEngine::sDecoderImpl = ccnew AudioEngineImpl();
         AudioEngineImpl::initDecoder();
     }
     return AudioEngine::sDecoderImpl;
+#else
+    return nullptr;
+#endif
 }
 
 PCMHeader AudioEngine::getPCMHeader(const char *url) {
-    return AudioEngine::getDecoderImpl()->getPCMHeader(url);
+    AudioEngineImpl *impl = AudioEngine::getDecoderImpl();
+    if (impl == nullptr) {
+        CC_LOG_WARNING("AudioEngine::getPCMHeader: audio engine unavailable, url: %s", url);
+        return {};
+    }
+    return impl->getPCMHeader(url);
 }
 
 ccstd::vector<uint8_t> AudioEngine::getOriginalPCMBuffer(const char *url, uint32_t channelID) {
-    return AudioEngine::getDecoderImpl()->getOriginalPCMBuffer(url, channelID);
+    AudioEngineImpl *impl = AudioEngine::getDecoderImpl();
+    if (impl == nullptr) {
+        CC_LOG_WARNING("AudioEngine::getOriginalPCMBuffer: audio engine unavailable, url: %s", url);
+        return {};
+    }
+    return impl->getOriginalPCMBuffer(url, channelID);
 }
 } // namespace cc

--- a/native/cocos/audio/android/AudioEngine-inl.cpp
+++ b/native/cocos/audio/android/AudioEngine-inl.cpp
@@ -29,9 +29,9 @@
 #include <unistd.h>
 // for native asset manager
 #if CC_PLATFORM == CC_PLATFORM_ANDROID
-#include <android/asset_manager.h>
-#include <android/asset_manager_jni.h>
-#include <android/log.h>
+    #include <android/asset_manager.h>
+    #include <android/asset_manager_jni.h>
+    #include <android/log.h>
 #endif
 
 #include <sys/types.h>
@@ -45,11 +45,11 @@
 #include "base/UTF8.h"
 #include "base/memory/Memory.h"
 #if CC_PLATFORM == CC_PLATFORM_ANDROID
-#include "platform/android/FileUtils-android.h"
-#include "platform/java/jni/JniHelper.h"
-#include "platform/java/jni/JniImp.h"
+    #include "platform/android/FileUtils-android.h"
+    #include "platform/java/jni/JniHelper.h"
+    #include "platform/java/jni/JniImp.h"
 #elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
-#include "cocos/platform/openharmony/FileUtils-OpenHarmony.h"
+    #include "cocos/platform/openharmony/FileUtils-OpenHarmony.h"
 #endif
 
 #include "audio/android/AudioDecoder.h"
@@ -61,27 +61,27 @@
 #include "audio/android/cutils/log.h"
 #include "engine/EngineEvents.h"
 
-using namespace cc; //NOLINT
+using namespace cc; // NOLINT
 
 // Audio focus values synchronized with which in cocos/platform/android/java/src/com/cocos/lib/CocosNativeActivity.java
 namespace {
 AudioEngineImpl *gAudioImpl = nullptr;
 int outputSampleRate = 44100;
 #if CC_PLATFORM == CC_PLATFORM_ANDROID
-int              bufferSizeInFrames = 192;
+int bufferSizeInFrames = 192;
 #endif
 
 void getAudioInfo() {
 #if CC_PLATFORM == CC_PLATFORM_ANDROID
-    JNIEnv *  env         = JniHelper::getEnv();
-    jclass    audioSystem = env->FindClass("android/media/AudioSystem");
-    jmethodID method      = env->GetStaticMethodID(audioSystem, "getPrimaryOutputSamplingRate", "()I");
-    outputSampleRate      = env->CallStaticIntMethod(audioSystem, method);
-    method                = env->GetStaticMethodID(audioSystem, "getPrimaryOutputFrameCount", "()I");
-    bufferSizeInFrames    = env->CallStaticIntMethod(audioSystem, method);
+    JNIEnv *env = JniHelper::getEnv();
+    jclass audioSystem = env->FindClass("android/media/AudioSystem");
+    jmethodID method = env->GetStaticMethodID(audioSystem, "getPrimaryOutputSamplingRate", "()I");
+    outputSampleRate = env->CallStaticIntMethod(audioSystem, method);
+    method = env->GetStaticMethodID(audioSystem, "getPrimaryOutputFrameCount", "()I");
+    bufferSizeInFrames = env->CallStaticIntMethod(audioSystem, method);
 #else
     // In openharmony, setting to 48K does not cause audio delays
-    outputSampleRate      = 48000;
+    outputSampleRate = 48000;
 #endif
 }
 } // namespace
@@ -123,8 +123,8 @@ static int fdGetter(const ccstd::string &url, off_t *start, off_t *length) {
         AAsset_close(asset);
     }
 #elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
-    FileUtilsOpenHarmony* fileUtils = dynamic_cast<FileUtilsOpenHarmony*>(FileUtils::getInstance());
-    if(fileUtils) {
+    FileUtilsOpenHarmony *fileUtils = dynamic_cast<FileUtilsOpenHarmony *>(FileUtils::getInstance());
+    if (fileUtils) {
         RawFileDescriptor64 descriptor;
         fileUtils->getRawFileDescriptor(url, descriptor);
         fd = descriptor.fd;
@@ -189,27 +189,27 @@ bool AudioEngineImpl::init() {
             CC_LOG_ERROR("get the engine interface fail");
             break;
         }
-		#if CC_PLATFORM == CC_PLATFORM_ANDROID
-	        // create output mix
-	        const SLInterfaceID outputMixIIDs[] = {};
-	        const SLboolean outputMixReqs[] = {};
-	        result = (*_engineEngine)->CreateOutputMix(_engineEngine, &_outputMixObject, 0, outputMixIIDs, outputMixReqs);
-	        if (SL_RESULT_SUCCESS != result) {
-	            CC_LOG_ERROR("create output mix fail");
-	            break;
-	        }
+#if CC_PLATFORM == CC_PLATFORM_ANDROID
+        // create output mix
+        const SLInterfaceID outputMixIIDs[] = {};
+        const SLboolean outputMixReqs[] = {};
+        result = (*_engineEngine)->CreateOutputMix(_engineEngine, &_outputMixObject, 0, outputMixIIDs, outputMixReqs);
+        if (SL_RESULT_SUCCESS != result) {
+            CC_LOG_ERROR("create output mix fail");
+            break;
+        }
 
-	        // realize the output mix
-	        result = (*_outputMixObject)->Realize(_outputMixObject, SL_BOOLEAN_FALSE);
-	        if (SL_RESULT_SUCCESS != result) {
-	            CC_LOG_ERROR("realize the output mix fail");
-	            break;
-	        }
+        // realize the output mix
+        result = (*_outputMixObject)->Realize(_outputMixObject, SL_BOOLEAN_FALSE);
+        if (SL_RESULT_SUCCESS != result) {
+            CC_LOG_ERROR("realize the output mix fail");
+            break;
+        }
 
-	        _audioPlayerProvider = ccnew AudioPlayerProvider(_engineEngine, _outputMixObject, outputSampleRate, bufferSizeInFrames, fdGetter, &gCallerThreadUtils);
-	    #elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
-	        _audioPlayerProvider = ccnew AudioPlayerProvider(_engineEngine, outputSampleRate, fdGetter, &gCallerThreadUtils);
-	    #endif
+        _audioPlayerProvider = ccnew AudioPlayerProvider(_engineEngine, _outputMixObject, outputSampleRate, bufferSizeInFrames, fdGetter, &gCallerThreadUtils);
+#elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
+        _audioPlayerProvider = ccnew AudioPlayerProvider(_engineEngine, outputSampleRate, fdGetter, &gCallerThreadUtils);
+#endif
         ret = true;
     } while (false);
 
@@ -227,14 +227,14 @@ int AudioEngineImpl::play2d(const ccstd::string &filePath, bool loop, float volu
     auto audioId = AudioEngine::INVALID_AUDIO_ID;
 
     do {
-		#if CC_PLATFORM == CC_PLATFORM_ANDROID
-	        if (_engineEngine == nullptr || _audioPlayerProvider == nullptr) {
-	            break;
-	        }
-        #elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
-	        if (_audioPlayerProvider == nullptr)
-	            break;
-        #endif
+#if CC_PLATFORM == CC_PLATFORM_ANDROID
+        if (_engineEngine == nullptr || _audioPlayerProvider == nullptr) {
+            break;
+        }
+#elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
+        if (_audioPlayerProvider == nullptr)
+            break;
+#endif
 
         auto fullPath = FileUtils::getInstance()->fullPathForFilename(filePath);
 
@@ -426,6 +426,12 @@ void AudioEngineImpl::onResume() {
     }
 }
 
+bool AudioEngineImpl::initDecoder() {
+    // On Android the decoder infrastructure is set up by init().
+    // This method exists so AudioEngine.cpp compiles uniformly across all platforms.
+    return true;
+}
+
 PCMHeader AudioEngineImpl::getPCMHeader(const char *url) {
     PCMHeader header{};
     ccstd::string fileFullPath = FileUtils::getInstance()->fullPathForFilename(url);
@@ -437,12 +443,12 @@ PCMHeader AudioEngineImpl::getPCMHeader(const char *url) {
         CC_LOG_DEBUG("file %s pcm data already cached", url);
         return header;
     }
-    #if CC_PLATFORM == CC_PLATFORM_ANDROID
+#if CC_PLATFORM == CC_PLATFORM_ANDROID
     AudioDecoder *decoder = AudioDecoderProvider::createAudioDecoder(_engineEngine, fileFullPath, bufferSizeInFrames, outputSampleRate, fdGetter);
-    #elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
+#elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
     AudioDecoder *decoder = AudioDecoderProvider::createAudioDecoder(
         _engineEngine, fileFullPath, _audioPlayerProvider->getBufferSizeInFrames(), outputSampleRate, fdGetter);
-    #endif
+#endif
     if (decoder == nullptr) {
         CC_LOG_DEBUG("decode %s failed, the file formate might not support", url);
         return header;
@@ -476,12 +482,12 @@ ccstd::vector<uint8_t> AudioEngineImpl::getOriginalPCMBuffer(const char *url, ui
     if (_audioPlayerProvider->getPcmData(url, data)) {
         CC_LOG_DEBUG("file %s pcm data already cached", url);
     } else {
-        #if CC_PLATFORM == CC_PLATFORM_ANDROID
+#if CC_PLATFORM == CC_PLATFORM_ANDROID
         AudioDecoder *decoder = AudioDecoderProvider::createAudioDecoder(_engineEngine, fileFullPath, bufferSizeInFrames, outputSampleRate, fdGetter);
-        #else 
+#else
         AudioDecoder *decoder = AudioDecoderProvider::createAudioDecoder(
             _engineEngine, fileFullPath, _audioPlayerProvider->getBufferSizeInFrames(), outputSampleRate, fdGetter);
-        #endif
+#endif
         if (decoder == nullptr) {
             CC_LOG_DEBUG("decode %s failed, the file formate might not support", url);
             return pcmData;

--- a/native/cocos/audio/android/AudioEngine-inl.cpp
+++ b/native/cocos/audio/android/AudioEngine-inl.cpp
@@ -189,7 +189,7 @@ bool AudioEngineImpl::init() {
             CC_LOG_ERROR("get the engine interface fail");
             break;
         }
-        #if CC_PLATFORM == CC_PLATFORM_ANDROID
+		#if CC_PLATFORM == CC_PLATFORM_ANDROID
 	        // create output mix
 	        const SLInterfaceID outputMixIIDs[] = {};
 	        const SLboolean outputMixReqs[] = {};
@@ -227,7 +227,7 @@ int AudioEngineImpl::play2d(const ccstd::string &filePath, bool loop, float volu
     auto audioId = AudioEngine::INVALID_AUDIO_ID;
 
     do {
-        #if CC_PLATFORM == CC_PLATFORM_ANDROID
+		#if CC_PLATFORM == CC_PLATFORM_ANDROID
 	        if (_engineEngine == nullptr || _audioPlayerProvider == nullptr) {
 	            break;
 	        }
@@ -482,12 +482,12 @@ ccstd::vector<uint8_t> AudioEngineImpl::getOriginalPCMBuffer(const char *url, ui
     if (_audioPlayerProvider->getPcmData(url, data)) {
         CC_LOG_DEBUG("file %s pcm data already cached", url);
     } else {
-    #if CC_PLATFORM == CC_PLATFORM_ANDROID
+        #if CC_PLATFORM == CC_PLATFORM_ANDROID
         AudioDecoder *decoder = AudioDecoderProvider::createAudioDecoder(_engineEngine, fileFullPath, bufferSizeInFrames, outputSampleRate, fdGetter);
-    #else
+        #else 
         AudioDecoder *decoder = AudioDecoderProvider::createAudioDecoder(
             _engineEngine, fileFullPath, _audioPlayerProvider->getBufferSizeInFrames(), outputSampleRate, fdGetter);
-    #endif
+        #endif
         if (decoder == nullptr) {
             CC_LOG_DEBUG("decode %s failed, the file formate might not support", url);
             return pcmData;

--- a/native/cocos/audio/android/AudioEngine-inl.cpp
+++ b/native/cocos/audio/android/AudioEngine-inl.cpp
@@ -29,9 +29,9 @@
 #include <unistd.h>
 // for native asset manager
 #if CC_PLATFORM == CC_PLATFORM_ANDROID
-    #include <android/asset_manager.h>
-    #include <android/asset_manager_jni.h>
-    #include <android/log.h>
+#include <android/asset_manager.h>
+#include <android/asset_manager_jni.h>
+#include <android/log.h>
 #endif
 
 #include <sys/types.h>
@@ -45,11 +45,11 @@
 #include "base/UTF8.h"
 #include "base/memory/Memory.h"
 #if CC_PLATFORM == CC_PLATFORM_ANDROID
-    #include "platform/android/FileUtils-android.h"
-    #include "platform/java/jni/JniHelper.h"
-    #include "platform/java/jni/JniImp.h"
+#include "platform/android/FileUtils-android.h"
+#include "platform/java/jni/JniHelper.h"
+#include "platform/java/jni/JniImp.h"
 #elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
-    #include "cocos/platform/openharmony/FileUtils-OpenHarmony.h"
+#include "cocos/platform/openharmony/FileUtils-OpenHarmony.h"
 #endif
 
 #include "audio/android/AudioDecoder.h"
@@ -61,27 +61,27 @@
 #include "audio/android/cutils/log.h"
 #include "engine/EngineEvents.h"
 
-using namespace cc; // NOLINT
+using namespace cc; //NOLINT
 
 // Audio focus values synchronized with which in cocos/platform/android/java/src/com/cocos/lib/CocosNativeActivity.java
 namespace {
 AudioEngineImpl *gAudioImpl = nullptr;
 int outputSampleRate = 44100;
 #if CC_PLATFORM == CC_PLATFORM_ANDROID
-int bufferSizeInFrames = 192;
+int              bufferSizeInFrames = 192;
 #endif
 
 void getAudioInfo() {
 #if CC_PLATFORM == CC_PLATFORM_ANDROID
-    JNIEnv *env = JniHelper::getEnv();
-    jclass audioSystem = env->FindClass("android/media/AudioSystem");
-    jmethodID method = env->GetStaticMethodID(audioSystem, "getPrimaryOutputSamplingRate", "()I");
-    outputSampleRate = env->CallStaticIntMethod(audioSystem, method);
-    method = env->GetStaticMethodID(audioSystem, "getPrimaryOutputFrameCount", "()I");
-    bufferSizeInFrames = env->CallStaticIntMethod(audioSystem, method);
+    JNIEnv *  env         = JniHelper::getEnv();
+    jclass    audioSystem = env->FindClass("android/media/AudioSystem");
+    jmethodID method      = env->GetStaticMethodID(audioSystem, "getPrimaryOutputSamplingRate", "()I");
+    outputSampleRate      = env->CallStaticIntMethod(audioSystem, method);
+    method                = env->GetStaticMethodID(audioSystem, "getPrimaryOutputFrameCount", "()I");
+    bufferSizeInFrames    = env->CallStaticIntMethod(audioSystem, method);
 #else
     // In openharmony, setting to 48K does not cause audio delays
-    outputSampleRate = 48000;
+    outputSampleRate      = 48000;
 #endif
 }
 } // namespace
@@ -123,8 +123,8 @@ static int fdGetter(const ccstd::string &url, off_t *start, off_t *length) {
         AAsset_close(asset);
     }
 #elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
-    FileUtilsOpenHarmony *fileUtils = dynamic_cast<FileUtilsOpenHarmony *>(FileUtils::getInstance());
-    if (fileUtils) {
+    FileUtilsOpenHarmony* fileUtils = dynamic_cast<FileUtilsOpenHarmony*>(FileUtils::getInstance());
+    if(fileUtils) {
         RawFileDescriptor64 descriptor;
         fileUtils->getRawFileDescriptor(url, descriptor);
         fd = descriptor.fd;
@@ -189,27 +189,27 @@ bool AudioEngineImpl::init() {
             CC_LOG_ERROR("get the engine interface fail");
             break;
         }
-#if CC_PLATFORM == CC_PLATFORM_ANDROID
-        // create output mix
-        const SLInterfaceID outputMixIIDs[] = {};
-        const SLboolean outputMixReqs[] = {};
-        result = (*_engineEngine)->CreateOutputMix(_engineEngine, &_outputMixObject, 0, outputMixIIDs, outputMixReqs);
-        if (SL_RESULT_SUCCESS != result) {
-            CC_LOG_ERROR("create output mix fail");
-            break;
-        }
+        #if CC_PLATFORM == CC_PLATFORM_ANDROID
+	        // create output mix
+	        const SLInterfaceID outputMixIIDs[] = {};
+	        const SLboolean outputMixReqs[] = {};
+	        result = (*_engineEngine)->CreateOutputMix(_engineEngine, &_outputMixObject, 0, outputMixIIDs, outputMixReqs);
+	        if (SL_RESULT_SUCCESS != result) {
+	            CC_LOG_ERROR("create output mix fail");
+	            break;
+	        }
 
-        // realize the output mix
-        result = (*_outputMixObject)->Realize(_outputMixObject, SL_BOOLEAN_FALSE);
-        if (SL_RESULT_SUCCESS != result) {
-            CC_LOG_ERROR("realize the output mix fail");
-            break;
-        }
+	        // realize the output mix
+	        result = (*_outputMixObject)->Realize(_outputMixObject, SL_BOOLEAN_FALSE);
+	        if (SL_RESULT_SUCCESS != result) {
+	            CC_LOG_ERROR("realize the output mix fail");
+	            break;
+	        }
 
-        _audioPlayerProvider = ccnew AudioPlayerProvider(_engineEngine, _outputMixObject, outputSampleRate, bufferSizeInFrames, fdGetter, &gCallerThreadUtils);
-#elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
-        _audioPlayerProvider = ccnew AudioPlayerProvider(_engineEngine, outputSampleRate, fdGetter, &gCallerThreadUtils);
-#endif
+	        _audioPlayerProvider = ccnew AudioPlayerProvider(_engineEngine, _outputMixObject, outputSampleRate, bufferSizeInFrames, fdGetter, &gCallerThreadUtils);
+	    #elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
+	        _audioPlayerProvider = ccnew AudioPlayerProvider(_engineEngine, outputSampleRate, fdGetter, &gCallerThreadUtils);
+	    #endif
         ret = true;
     } while (false);
 
@@ -227,14 +227,14 @@ int AudioEngineImpl::play2d(const ccstd::string &filePath, bool loop, float volu
     auto audioId = AudioEngine::INVALID_AUDIO_ID;
 
     do {
-#if CC_PLATFORM == CC_PLATFORM_ANDROID
-        if (_engineEngine == nullptr || _audioPlayerProvider == nullptr) {
-            break;
-        }
-#elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
-        if (_audioPlayerProvider == nullptr)
-            break;
-#endif
+        #if CC_PLATFORM == CC_PLATFORM_ANDROID
+	        if (_engineEngine == nullptr || _audioPlayerProvider == nullptr) {
+	            break;
+	        }
+        #elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
+	        if (_audioPlayerProvider == nullptr)
+	            break;
+        #endif
 
         auto fullPath = FileUtils::getInstance()->fullPathForFilename(filePath);
 
@@ -443,12 +443,12 @@ PCMHeader AudioEngineImpl::getPCMHeader(const char *url) {
         CC_LOG_DEBUG("file %s pcm data already cached", url);
         return header;
     }
-#if CC_PLATFORM == CC_PLATFORM_ANDROID
+    #if CC_PLATFORM == CC_PLATFORM_ANDROID
     AudioDecoder *decoder = AudioDecoderProvider::createAudioDecoder(_engineEngine, fileFullPath, bufferSizeInFrames, outputSampleRate, fdGetter);
-#elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
+    #elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
     AudioDecoder *decoder = AudioDecoderProvider::createAudioDecoder(
         _engineEngine, fileFullPath, _audioPlayerProvider->getBufferSizeInFrames(), outputSampleRate, fdGetter);
-#endif
+    #endif
     if (decoder == nullptr) {
         CC_LOG_DEBUG("decode %s failed, the file formate might not support", url);
         return header;
@@ -482,12 +482,12 @@ ccstd::vector<uint8_t> AudioEngineImpl::getOriginalPCMBuffer(const char *url, ui
     if (_audioPlayerProvider->getPcmData(url, data)) {
         CC_LOG_DEBUG("file %s pcm data already cached", url);
     } else {
-#if CC_PLATFORM == CC_PLATFORM_ANDROID
+    #if CC_PLATFORM == CC_PLATFORM_ANDROID
         AudioDecoder *decoder = AudioDecoderProvider::createAudioDecoder(_engineEngine, fileFullPath, bufferSizeInFrames, outputSampleRate, fdGetter);
-#else
+    #else
         AudioDecoder *decoder = AudioDecoderProvider::createAudioDecoder(
             _engineEngine, fileFullPath, _audioPlayerProvider->getBufferSizeInFrames(), outputSampleRate, fdGetter);
-#endif
+    #endif
         if (decoder == nullptr) {
             CC_LOG_DEBUG("decode %s failed, the file formate might not support", url);
             return pcmData;

--- a/native/cocos/audio/android/AudioEngine-inl.h
+++ b/native/cocos/audio/android/AudioEngine-inl.h
@@ -55,7 +55,7 @@ public:
     ~AudioEngineImpl() override;
 
     bool init();
-    bool initDecoder();
+    static bool initDecoder();
     int play2d(const ccstd::string &filePath, bool loop, float volume);
     void setVolume(int audioID, float volume);
     void setLoop(int audioID, bool loop);

--- a/native/cocos/audio/android/AudioEngine-inl.h
+++ b/native/cocos/audio/android/AudioEngine-inl.h
@@ -26,9 +26,9 @@
 
 #include <SLES/OpenSLES.h>
 #if CC_PLATFORM == CC_PLATFORM_ANDROID
-#include <SLES/OpenSLES_Android.h>
+    #include <SLES/OpenSLES_Android.h>
 #elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
-#include <SLES/OpenSLES_Platform.h>
+    #include <SLES/OpenSLES_Platform.h>
 #endif
 #include <functional>
 #include "audio/include/AudioDef.h"
@@ -55,6 +55,7 @@ public:
     ~AudioEngineImpl() override;
 
     bool init();
+    bool initDecoder();
     int play2d(const ccstd::string &filePath, bool loop, float volume);
     void setVolume(int audioID, float volume);
     void setLoop(int audioID, bool loop);
@@ -88,7 +89,7 @@ private:
     // output mix interfaces
     SLObjectItf _outputMixObject;
 
-    //audioID,AudioInfo
+    // audioID,AudioInfo
     ccstd::unordered_map<int, IAudioPlayer *> _audioPlayers;
     ccstd::unordered_map<int, std::function<void(int, const ccstd::string &)>> _callbackMap;
 

--- a/native/cocos/audio/android/AudioEngine-inl.h
+++ b/native/cocos/audio/android/AudioEngine-inl.h
@@ -26,9 +26,9 @@
 
 #include <SLES/OpenSLES.h>
 #if CC_PLATFORM == CC_PLATFORM_ANDROID
-    #include <SLES/OpenSLES_Android.h>
+#include <SLES/OpenSLES_Android.h>
 #elif CC_PLATFORM == CC_PLATFORM_OPENHARMONY
-    #include <SLES/OpenSLES_Platform.h>
+#include <SLES/OpenSLES_Platform.h>
 #endif
 #include <functional>
 #include "audio/include/AudioDef.h"

--- a/native/cocos/audio/android/AudioEngine-inl.h
+++ b/native/cocos/audio/android/AudioEngine-inl.h
@@ -89,7 +89,7 @@ private:
     // output mix interfaces
     SLObjectItf _outputMixObject;
 
-    // audioID,AudioInfo
+    //audioID,AudioInfo
     ccstd::unordered_map<int, IAudioPlayer *> _audioPlayers;
     ccstd::unordered_map<int, std::function<void(int, const ccstd::string &)>> _callbackMap;
 

--- a/native/cocos/audio/apple/AudioEngine-inl.h
+++ b/native/cocos/audio/apple/AudioEngine-inl.h
@@ -74,13 +74,13 @@ private:
 
     ALuint _alSources[MAX_AUDIOINSTANCES];
 
-    // source,used
+    //source,used
     ccstd::list<ALuint> _unusedSourcesPool;
 
-    // filePath,bufferInfo
+    //filePath,bufferInfo
     ccstd::unordered_map<ccstd::string, AudioCache> _audioCaches;
 
-    // audioID,AudioInfo
+    //audioID,AudioInfo
     ccstd::unordered_map<int, AudioPlayer *> _audioPlayers;
     std::mutex _threadMutex;
 

--- a/native/cocos/audio/apple/AudioEngine-inl.h
+++ b/native/cocos/audio/apple/AudioEngine-inl.h
@@ -43,7 +43,7 @@ public:
     ~AudioEngineImpl();
 
     bool init();
-    bool initDecoder();
+    static bool initDecoder();
     int play2d(const ccstd::string &fileFullPath, bool loop, float volume);
     void setVolume(int audioID, float volume);
     void setLoop(int audioID, bool loop);

--- a/native/cocos/audio/apple/AudioEngine-inl.h
+++ b/native/cocos/audio/apple/AudioEngine-inl.h
@@ -43,6 +43,7 @@ public:
     ~AudioEngineImpl();
 
     bool init();
+    bool initDecoder();
     int play2d(const ccstd::string &fileFullPath, bool loop, float volume);
     void setVolume(int audioID, float volume);
     void setLoop(int audioID, bool loop);
@@ -73,13 +74,13 @@ private:
 
     ALuint _alSources[MAX_AUDIOINSTANCES];
 
-    //source,used
+    // source,used
     ccstd::list<ALuint> _unusedSourcesPool;
 
-    //filePath,bufferInfo
+    // filePath,bufferInfo
     ccstd::unordered_map<ccstd::string, AudioCache> _audioCaches;
 
-    //audioID,AudioInfo
+    // audioID,AudioInfo
     ccstd::unordered_map<int, AudioPlayer *> _audioPlayers;
     std::mutex _threadMutex;
 

--- a/native/cocos/audio/apple/AudioEngine-inl.mm
+++ b/native/cocos/audio/apple/AudioEngine-inl.mm
@@ -632,6 +632,12 @@ bool AudioEngineImpl::checkAudioIdValid(int audioID) {
     return _audioPlayers.find(audioID) != _audioPlayers.end();
 }
 
+bool AudioEngineImpl::initDecoder() {
+    // On Apple the decoder infrastructure is set up by init().
+    // This method exists so AudioEngine.cpp compiles uniformly across all platforms.
+    return true;
+}
+
 PCMHeader AudioEngineImpl::getPCMHeader(const char *url){
     PCMHeader header {};
     auto itr = _audioCaches.find(url);

--- a/native/cocos/audio/include/AudioEngine.h
+++ b/native/cocos/audio/include/AudioEngine.h
@@ -55,9 +55,9 @@ namespace cc {
  */
 class EXPORT_DLL AudioProfile {
 public:
-    // Profile name can't be empty.
+    //Profile name can't be empty.
     ccstd::string name;
-    // The maximum number of simultaneous audio instance.
+    //The maximum number of simultaneous audio instance.
     unsigned int maxInstances{};
 
     /* Minimum delay in between sounds */
@@ -106,14 +106,14 @@ public:
      */
     static void end();
 
-    /**
+    /**  
      * Gets the default profile of audio instances.
      *
      * @return The default profile of audio instances.
      */
     static AudioProfile *getDefaultProfile();
 
-    /**
+    /**  
      * Play 2d sound.
      *
      * @param filePath The path of an audio file.
@@ -126,7 +126,7 @@ public:
      */
     static int play2d(const ccstd::string &filePath, bool loop = false, float volume = 1.0F, const AudioProfile *profile = nullptr);
 
-    /**
+    /**  
      * Sets whether an audio instance loop or not.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -134,7 +134,7 @@ public:
      */
     static void setLoop(int audioID, bool loop);
 
-    /**
+    /**  
      * Checks whether an audio instance is loop.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -142,7 +142,7 @@ public:
      */
     static bool isLoop(int audioID);
 
-    /**
+    /**  
      * Sets volume for an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -164,7 +164,7 @@ public:
      */
     static float getVolume(int audioID);
 
-    /**
+    /**  
      * Pause an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -174,7 +174,7 @@ public:
     /** Pause all playing audio instances. */
     static void pauseAll();
 
-    /**
+    /**  
      * Resume an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -184,7 +184,7 @@ public:
     /** Resume all suspended audio instances. */
     static void resumeAll();
 
-    /**
+    /**  
      * Stop an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -199,11 +199,11 @@ public:
      *
      * @param audioID   An audioID returned by the play2d function.
      * @param time      The offset in seconds from the start to seek to.
-     * @return
+     * @return 
      */
     static bool setCurrentTime(int audioID, float time);
 
-    /**
+    /**  
      * Gets the current playback position of an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -211,7 +211,7 @@ public:
      */
     static float getCurrentTime(int audioID);
 
-    /**
+    /**  
      * Gets the duration of an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -219,15 +219,15 @@ public:
      */
     static float getDuration(int audioID);
 
-    /**
-     * Gets the duration of an audio file.
-     *
-     * @param filePath The path of an audio file.
-     * @return The duration of an audio file.
-     */
+    /** 
+    * Gets the duration of an audio file.
+    *
+    * @param filePath The path of an audio file.
+    * @return The duration of an audio file.
+    */
     static float getDurationFromFile(const ccstd::string &filePath);
 
-    /**
+    /** 
      * Returns the state of an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -235,7 +235,7 @@ public:
      */
     static AudioState getState(int audioID);
 
-    /**
+    /** 
      * Register a callback to be invoked when an audio instance has completed playing.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -255,7 +255,7 @@ public:
      */
     static bool setMaxAudioInstance(int maxInstances);
 
-    /**
+    /** 
      * Uncache the audio data from internal buffer.
      * AudioEngine cache audio data on ios,mac, and oalsoft platform.
      *
@@ -264,14 +264,14 @@ public:
      */
     static void uncache(const ccstd::string &filePath);
 
-    /**
+    /** 
      * Uncache all audio data from internal buffer.
      *
      * @warning All audio will be stopped first.
      */
     static void uncacheAll();
 
-    /**
+    /** 
      * Gets the audio profile by id of audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -279,7 +279,7 @@ public:
      */
     static AudioProfile *getProfile(int audioID);
 
-    /**
+    /** 
      * Gets an audio profile by name.
      *
      * @param profileName A name of audio profile.
@@ -317,7 +317,7 @@ public:
 
     /**
      * @brief Get the PCMHeader of audio
-     *
+     * 
      * @param url The file url of an audio. same as filePath
      * @return PCMHeader of audio
      */
@@ -325,8 +325,8 @@ public:
 
     /**
      * @brief Get the Buffer object
-     *
-     * @param channelID as there might be several channels at same time, select one to get buffer.
+     * 
+     * @param channelID as there might be several channels at same time, select one to get buffer. 
      * Start from 0
      * @return PCM datas behave as a ccstd::vector<char>. You can check byte length in PCMHeader.
      */
@@ -381,13 +381,13 @@ protected:
         AudioInfo &operator=(AudioInfo &&info) noexcept;
     };
 
-    // audioID,audioAttribute
+    //audioID,audioAttribute
     static ccstd::unordered_map<int, AudioInfo> sAudioIDInfoMap;
 
-    // audio file path,audio IDs
+    //audio file path,audio IDs
     static ccstd::unordered_map<ccstd::string, ccstd::list<int>> sAudioPathIDMap;
 
-    // profileName,ProfileHelper
+    //profileName,ProfileHelper
     static ccstd::unordered_map<ccstd::string, ProfileHelper> sAudioPathProfileHelperMap;
 
     static unsigned int sMaxInstances;

--- a/native/cocos/audio/include/AudioEngine.h
+++ b/native/cocos/audio/include/AudioEngine.h
@@ -113,7 +113,7 @@ public:
      */
     static AudioProfile *getDefaultProfile();
 
-    /**  
+    /** 
      * Play 2d sound.
      *
      * @param filePath The path of an audio file.
@@ -126,7 +126,7 @@ public:
      */
     static int play2d(const ccstd::string &filePath, bool loop = false, float volume = 1.0F, const AudioProfile *profile = nullptr);
 
-    /**  
+    /** 
      * Sets whether an audio instance loop or not.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -134,7 +134,7 @@ public:
      */
     static void setLoop(int audioID, bool loop);
 
-    /**  
+    /** 
      * Checks whether an audio instance is loop.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -142,7 +142,7 @@ public:
      */
     static bool isLoop(int audioID);
 
-    /**  
+    /** 
      * Sets volume for an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -164,7 +164,7 @@ public:
      */
     static float getVolume(int audioID);
 
-    /**  
+    /** 
      * Pause an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -174,7 +174,7 @@ public:
     /** Pause all playing audio instances. */
     static void pauseAll();
 
-    /**  
+    /** 
      * Resume an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -203,7 +203,7 @@ public:
      */
     static bool setCurrentTime(int audioID, float time);
 
-    /**  
+    /** 
      * Gets the current playback position of an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -211,7 +211,7 @@ public:
      */
     static float getCurrentTime(int audioID);
 
-    /**  
+    /** 
      * Gets the duration of an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -271,7 +271,7 @@ public:
      */
     static void uncacheAll();
 
-    /** 
+    /**  
      * Gets the audio profile by id of audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -279,7 +279,7 @@ public:
      */
     static AudioProfile *getProfile(int audioID);
 
-    /** 
+    /**  
      * Gets an audio profile by name.
      *
      * @param profileName A name of audio profile.

--- a/native/cocos/audio/include/AudioEngine.h
+++ b/native/cocos/audio/include/AudioEngine.h
@@ -55,9 +55,9 @@ namespace cc {
  */
 class EXPORT_DLL AudioProfile {
 public:
-    //Profile name can't be empty.
+    // Profile name can't be empty.
     ccstd::string name;
-    //The maximum number of simultaneous audio instance.
+    // The maximum number of simultaneous audio instance.
     unsigned int maxInstances{};
 
     /* Minimum delay in between sounds */
@@ -106,14 +106,14 @@ public:
      */
     static void end();
 
-    /**  
+    /**
      * Gets the default profile of audio instances.
      *
      * @return The default profile of audio instances.
      */
     static AudioProfile *getDefaultProfile();
 
-    /** 
+    /**
      * Play 2d sound.
      *
      * @param filePath The path of an audio file.
@@ -126,7 +126,7 @@ public:
      */
     static int play2d(const ccstd::string &filePath, bool loop = false, float volume = 1.0F, const AudioProfile *profile = nullptr);
 
-    /** 
+    /**
      * Sets whether an audio instance loop or not.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -134,7 +134,7 @@ public:
      */
     static void setLoop(int audioID, bool loop);
 
-    /** 
+    /**
      * Checks whether an audio instance is loop.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -142,7 +142,7 @@ public:
      */
     static bool isLoop(int audioID);
 
-    /** 
+    /**
      * Sets volume for an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -164,7 +164,7 @@ public:
      */
     static float getVolume(int audioID);
 
-    /** 
+    /**
      * Pause an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -174,7 +174,7 @@ public:
     /** Pause all playing audio instances. */
     static void pauseAll();
 
-    /** 
+    /**
      * Resume an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -184,7 +184,7 @@ public:
     /** Resume all suspended audio instances. */
     static void resumeAll();
 
-    /** 
+    /**
      * Stop an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -199,11 +199,11 @@ public:
      *
      * @param audioID   An audioID returned by the play2d function.
      * @param time      The offset in seconds from the start to seek to.
-     * @return 
+     * @return
      */
     static bool setCurrentTime(int audioID, float time);
 
-    /** 
+    /**
      * Gets the current playback position of an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -211,7 +211,7 @@ public:
      */
     static float getCurrentTime(int audioID);
 
-    /** 
+    /**
      * Gets the duration of an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -219,15 +219,15 @@ public:
      */
     static float getDuration(int audioID);
 
-    /** 
-    * Gets the duration of an audio file.
-    *
-    * @param filePath The path of an audio file.
-    * @return The duration of an audio file.
-    */
+    /**
+     * Gets the duration of an audio file.
+     *
+     * @param filePath The path of an audio file.
+     * @return The duration of an audio file.
+     */
     static float getDurationFromFile(const ccstd::string &filePath);
 
-    /** 
+    /**
      * Returns the state of an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -235,7 +235,7 @@ public:
      */
     static AudioState getState(int audioID);
 
-    /** 
+    /**
      * Register a callback to be invoked when an audio instance has completed playing.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -255,7 +255,7 @@ public:
      */
     static bool setMaxAudioInstance(int maxInstances);
 
-    /** 
+    /**
      * Uncache the audio data from internal buffer.
      * AudioEngine cache audio data on ios,mac, and oalsoft platform.
      *
@@ -264,14 +264,14 @@ public:
      */
     static void uncache(const ccstd::string &filePath);
 
-    /** 
+    /**
      * Uncache all audio data from internal buffer.
      *
      * @warning All audio will be stopped first.
      */
     static void uncacheAll();
 
-    /**  
+    /**
      * Gets the audio profile by id of audio instance.
      *
      * @param audioID An audioID returned by the play2d function.
@@ -279,7 +279,7 @@ public:
      */
     static AudioProfile *getProfile(int audioID);
 
-    /**  
+    /**
      * Gets an audio profile by name.
      *
      * @param profileName A name of audio profile.
@@ -317,7 +317,7 @@ public:
 
     /**
      * @brief Get the PCMHeader of audio
-     * 
+     *
      * @param url The file url of an audio. same as filePath
      * @return PCMHeader of audio
      */
@@ -325,8 +325,8 @@ public:
 
     /**
      * @brief Get the Buffer object
-     * 
-     * @param channelID as there might be several channels at same time, select one to get buffer. 
+     *
+     * @param channelID as there might be several channels at same time, select one to get buffer.
      * Start from 0
      * @return PCM datas behave as a ccstd::vector<char>. You can check byte length in PCMHeader.
      */
@@ -338,6 +338,19 @@ protected:
 
     static void pauseAll(ccstd::vector<int> *pausedAudioIDs);
     static void resumeAll(ccstd::vector<int> *pausedAudioIDs);
+
+    /**
+     * @brief Get Audio Decoder
+     *
+     * Strategy:
+     *      1. If the full impl (with OpenAL) is already alive, reuse it (cache + decoder both available).
+     *      2. If OpenAL init has not been attempted yet, try lazyInit() so that a successful OpenAL
+     *          environment still gets the full impl (keeps _audioCaches coherent with play2d).
+     *      3. Only fall back to the decoder-only sDecoderImpl when lazyInit() has failed
+     *          (alcOpenDevice returned null, headless / OHOS / CI environments).
+     * @return The impl instance to use for PCM decoding.
+     */
+    static AudioEngineImpl *getDecoderImpl();
 
     struct ProfileHelper {
         AudioProfile profile;
@@ -368,13 +381,13 @@ protected:
         AudioInfo &operator=(AudioInfo &&info) noexcept;
     };
 
-    //audioID,audioAttribute
+    // audioID,audioAttribute
     static ccstd::unordered_map<int, AudioInfo> sAudioIDInfoMap;
 
-    //audio file path,audio IDs
+    // audio file path,audio IDs
     static ccstd::unordered_map<ccstd::string, ccstd::list<int>> sAudioPathIDMap;
 
-    //profileName,ProfileHelper
+    // profileName,ProfileHelper
     static ccstd::unordered_map<ccstd::string, ProfileHelper> sAudioPathProfileHelperMap;
 
     static unsigned int sMaxInstances;
@@ -382,6 +395,10 @@ protected:
     static ProfileHelper *sDefaultProfileHelper;
 
     static AudioEngineImpl *sAudioEngineImpl;
+    // Decoder-only fallback instance used when OpenAL is unavailable.
+    // getPCMHeader / getOriginalPCMBuffer do not depend on OpenAL and use this
+    // instance directly instead of going through lazyInit().
+    static AudioEngineImpl *sDecoderImpl;
 
     class AudioEngineThreadPool;
     static AudioEngineThreadPool *sThreadPool;

--- a/native/cocos/audio/include/AudioEngine.h
+++ b/native/cocos/audio/include/AudioEngine.h
@@ -184,7 +184,7 @@ public:
     /** Resume all suspended audio instances. */
     static void resumeAll();
 
-    /**  
+    /** 
      * Stop an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.

--- a/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
+++ b/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
@@ -179,8 +179,7 @@ bool AudioEngineImpl::init() {
         alcMakeContextCurrent(sALContext);
 
         std::fill(std::begin(_alSources), std::end(_alSources), 0); 
-            src = 0;
-        }
+
         alGenSources(MAX_AUDIOINSTANCES, _alSources);
         auto alError = alGetError();
         if (alError != AL_NO_ERROR) {

--- a/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
+++ b/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
@@ -178,10 +178,16 @@ bool AudioEngineImpl::init() {
 
         alcMakeContextCurrent(sALContext);
 
+        for (auto &src : _alSources) {
+            src = 0;
+        }
         alGenSources(MAX_AUDIOINSTANCES, _alSources);
         auto alError = alGetError();
         if (alError != AL_NO_ERROR) {
             CC_LOG_ERROR("%s:generating sources failed! error = %x\n", __FUNCTION__, alError);
+            alcMakeContextCurrent(nullptr);
+            alcDestroyContext(sALContext);
+            sALContext = nullptr;
             break;
         }
 

--- a/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
+++ b/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
@@ -62,7 +62,7 @@
 // log, CC_LOG_DEBUG aren't threadsafe, since we uses sub threads for parsing pcm data, threadsafe log output
 // is needed. Define the following macros (ALOGV, ALOGD, ALOGI, ALOGW, ALOGE) for threadsafe log output.
 
-// IDEA: Move _winLog, winLog to a separated file
+// IDEA: Move _winLog, winLog to a separate file
 static void _winLog(const char *format, va_list args) {
     static const int MAX_LOG_LENGTH = 16 * 1024;
     int bufferSize = MAX_LOG_LENGTH;
@@ -284,7 +284,7 @@ int AudioEngineImpl::play2d(const ccstd::string &filePath, bool loop, float volu
 }
 
 void AudioEngineImpl::play2dImpl(AudioCache *cache, int audioID) {
-    // Note: It may bn in sub thread or main thread :(
+    // Note: It may be in sub thread or main thread :(
     if (!*cache->_isDestroyed && cache->_state == AudioCache::State::READY) {
         _threadMutex.lock();
         auto playerIt = _audioPlayers.find(audioID);

--- a/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
+++ b/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
@@ -120,7 +120,7 @@ void audioLog(const char *format, ...) {
 
 #endif
 
-using namespace cc; // NOLINT
+using namespace cc; //NOLINT
 
 static ALCdevice *sALDevice = nullptr;
 static ALCcontext *sALContext = nullptr;
@@ -388,9 +388,9 @@ void AudioEngineImpl::stop(int audioID) {
     }
     auto player = _audioPlayers[audioID];
     player->destroy();
-    // Note: Don't set the flag to false here, it should be set in 'update' function.
-    //  Otherwise, the state got from alSourceState may be wrong
-    //     _alSourceUsed[player->_alSource] = false;
+    //Note: Don't set the flag to false here, it should be set in 'update' function.
+    // Otherwise, the state got from alSourceState may be wrong
+    //    _alSourceUsed[player->_alSource] = false;
 
     // Call 'update' method to cleanup immediately since the schedule may be cancelled without any notification.
     update(0.0F);
@@ -400,12 +400,12 @@ void AudioEngineImpl::stopAll() {
     for (auto &&player : _audioPlayers) {
         player.second->destroy();
     }
-    // Note: Don't set the flag to false here, it should be set in 'update' function.
-    //  Otherwise, the state got from alSourceState may be wrong
-    //     for(int index = 0; index < MAX_AUDIOINSTANCES; ++index)
-    //     {
-    //         _alSourceUsed[_alSources[index]] = false;
-    //     }
+    //Note: Don't set the flag to false here, it should be set in 'update' function.
+    // Otherwise, the state got from alSourceState may be wrong
+    //    for(int index = 0; index < MAX_AUDIOINSTANCES; ++index)
+    //    {
+    //        _alSourceUsed[_alSources[index]] = false;
+    //    }
 
     // Call 'update' method to cleanup immediately since the schedule may be cancelled without any notification.
     update(0.0F);
@@ -535,7 +535,7 @@ void AudioEngineImpl::update(float /*dt*/) {
             _threadMutex.unlock();
 
             if (player->_finishCallbak) {
-                player->_finishCallbak(audioID, filePath); // IDEA: callback will delay 50ms
+                player->_finishCallbak(audioID, filePath); //IDEA: callback will delay 50ms
             }
             delete player;
             _alSourceUsed[alSource] = false;

--- a/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
+++ b/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
@@ -178,7 +178,7 @@ bool AudioEngineImpl::init() {
 
         alcMakeContextCurrent(sALContext);
 
-        for (auto &src : _alSources) {
+        std::fill(std::begin(_alSources), std::end(_alSources), 0); 
             src = 0;
         }
         alGenSources(MAX_AUDIOINSTANCES, _alSources);

--- a/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
+++ b/native/cocos/audio/oalsoft/AudioEngine-soft.cpp
@@ -62,7 +62,7 @@
 // log, CC_LOG_DEBUG aren't threadsafe, since we uses sub threads for parsing pcm data, threadsafe log output
 // is needed. Define the following macros (ALOGV, ALOGD, ALOGI, ALOGW, ALOGE) for threadsafe log output.
 
-//IDEA: Move _winLog, winLog to a separated file
+// IDEA: Move _winLog, winLog to a separated file
 static void _winLog(const char *format, va_list args) {
     static const int MAX_LOG_LENGTH = 16 * 1024;
     int bufferSize = MAX_LOG_LENGTH;
@@ -120,7 +120,7 @@ void audioLog(const char *format, ...) {
 
 #endif
 
-using namespace cc; //NOLINT
+using namespace cc; // NOLINT
 
 static ALCdevice *sALDevice = nullptr;
 static ALCcontext *sALContext = nullptr;
@@ -153,31 +153,45 @@ AudioEngineImpl::~AudioEngineImpl() {
     AudioDecoderManager::destroy();
 }
 
+bool AudioEngineImpl::initDecoder() {
+    return AudioDecoderManager::init();
+}
+
 bool AudioEngineImpl::init() {
     bool ret = false;
     do {
         sALDevice = alcOpenDevice(nullptr);
-
-        if (sALDevice) {
-            alGetError();
-            sALContext = alcCreateContext(sALDevice, nullptr);
-            alcMakeContextCurrent(sALContext);
-
-            alGenSources(MAX_AUDIOINSTANCES, _alSources);
-            auto alError = alGetError();
-            if (alError != AL_NO_ERROR) {
-                CC_LOG_ERROR("%s:generating sources failed! error = %x\n", __FUNCTION__, alError);
-                break;
-            }
-
-            for (unsigned int src : _alSources) {
-                _alSourceUsed[src] = false;
-            }
-
-            _scheduler = CC_CURRENT_ENGINE()->getScheduler();
-            ret = AudioDecoderManager::init();
-            CC_LOG_DEBUG("OpenAL was initialized successfully!");
+        if (sALDevice == nullptr) {
+            // alcGetError(nullptr) is valid when no device is open
+            ALCenum alcErr = alcGetError(nullptr);
+            CC_LOG_ERROR("%s: alcOpenDevice failed, ALC error = 0x%x", __FUNCTION__, alcErr);
+            break;
         }
+
+        alGetError();
+        sALContext = alcCreateContext(sALDevice, nullptr);
+        if (sALContext == nullptr) {
+            ALCenum alcErr = alcGetError(sALDevice);
+            CC_LOG_ERROR("%s: alcCreateContext failed, ALC error = 0x%x", __FUNCTION__, alcErr);
+            break;
+        }
+
+        alcMakeContextCurrent(sALContext);
+
+        alGenSources(MAX_AUDIOINSTANCES, _alSources);
+        auto alError = alGetError();
+        if (alError != AL_NO_ERROR) {
+            CC_LOG_ERROR("%s:generating sources failed! error = %x\n", __FUNCTION__, alError);
+            break;
+        }
+
+        for (unsigned int src : _alSources) {
+            _alSourceUsed[src] = false;
+        }
+
+        _scheduler = CC_CURRENT_ENGINE()->getScheduler();
+        ret = initDecoder();
+        CC_LOG_DEBUG("OpenAL was initialized successfully!");
     } while (false);
 
     return ret;
@@ -264,7 +278,7 @@ int AudioEngineImpl::play2d(const ccstd::string &filePath, bool loop, float volu
 }
 
 void AudioEngineImpl::play2dImpl(AudioCache *cache, int audioID) {
-    //Note: It may bn in sub thread or main thread :(
+    // Note: It may bn in sub thread or main thread :(
     if (!*cache->_isDestroyed && cache->_state == AudioCache::State::READY) {
         _threadMutex.lock();
         auto playerIt = _audioPlayers.find(audioID);
@@ -368,9 +382,9 @@ void AudioEngineImpl::stop(int audioID) {
     }
     auto player = _audioPlayers[audioID];
     player->destroy();
-    //Note: Don't set the flag to false here, it should be set in 'update' function.
-    // Otherwise, the state got from alSourceState may be wrong
-    //    _alSourceUsed[player->_alSource] = false;
+    // Note: Don't set the flag to false here, it should be set in 'update' function.
+    //  Otherwise, the state got from alSourceState may be wrong
+    //     _alSourceUsed[player->_alSource] = false;
 
     // Call 'update' method to cleanup immediately since the schedule may be cancelled without any notification.
     update(0.0F);
@@ -380,12 +394,12 @@ void AudioEngineImpl::stopAll() {
     for (auto &&player : _audioPlayers) {
         player.second->destroy();
     }
-    //Note: Don't set the flag to false here, it should be set in 'update' function.
-    // Otherwise, the state got from alSourceState may be wrong
-    //    for(int index = 0; index < MAX_AUDIOINSTANCES; ++index)
-    //    {
-    //        _alSourceUsed[_alSources[index]] = false;
-    //    }
+    // Note: Don't set the flag to false here, it should be set in 'update' function.
+    //  Otherwise, the state got from alSourceState may be wrong
+    //     for(int index = 0; index < MAX_AUDIOINSTANCES; ++index)
+    //     {
+    //         _alSourceUsed[_alSources[index]] = false;
+    //     }
 
     // Call 'update' method to cleanup immediately since the schedule may be cancelled without any notification.
     update(0.0F);
@@ -515,7 +529,7 @@ void AudioEngineImpl::update(float /*dt*/) {
             _threadMutex.unlock();
 
             if (player->_finishCallbak) {
-                player->_finishCallbak(audioID, filePath); //IDEA: callback will delay 50ms
+                player->_finishCallbak(audioID, filePath); // IDEA: callback will delay 50ms
             }
             delete player;
             _alSourceUsed[alSource] = false;

--- a/native/cocos/audio/oalsoft/AudioEngine-soft.h
+++ b/native/cocos/audio/oalsoft/AudioEngine-soft.h
@@ -45,6 +45,9 @@ public:
     ~AudioEngineImpl() override;
 
     bool init();
+    // Initialize only the PCM decoder subsystem (AudioDecoderManager).
+    // Does not require an OpenAL device. Safe to call when init() failed.
+    bool initDecoder();
     int play2d(const ccstd::string &filePath, bool loop, float volume);
     void setVolume(int audioID, float volume);
     void setLoop(int audioID, bool loop);
@@ -71,13 +74,13 @@ private:
 
     ALuint _alSources[MAX_AUDIOINSTANCES];
 
-    //source,used
+    // source,used
     ccstd::unordered_map<ALuint, bool> _alSourceUsed;
 
-    //filePath,bufferInfo
+    // filePath,bufferInfo
     ccstd::unordered_map<ccstd::string, AudioCache> _audioCaches;
 
-    //audioID,AudioInfo
+    // audioID,AudioInfo
     ccstd::unordered_map<int, AudioPlayer *> _audioPlayers;
     std::mutex _threadMutex;
 

--- a/native/cocos/audio/oalsoft/AudioEngine-soft.h
+++ b/native/cocos/audio/oalsoft/AudioEngine-soft.h
@@ -74,13 +74,13 @@ private:
 
     ALuint _alSources[MAX_AUDIOINSTANCES];
 
-    // source,used
+    //source,used
     ccstd::unordered_map<ALuint, bool> _alSourceUsed;
 
-    // filePath,bufferInfo
+    //filePath,bufferInfo
     ccstd::unordered_map<ccstd::string, AudioCache> _audioCaches;
 
-    // audioID,AudioInfo
+    //audioID,AudioInfo
     ccstd::unordered_map<int, AudioPlayer *> _audioPlayers;
     std::mutex _threadMutex;
 

--- a/native/cocos/audio/oalsoft/AudioEngine-soft.h
+++ b/native/cocos/audio/oalsoft/AudioEngine-soft.h
@@ -47,7 +47,7 @@ public:
     bool init();
     // Initialize only the PCM decoder subsystem (AudioDecoderManager).
     // Does not require an OpenAL device. Safe to call when init() failed.
-    bool initDecoder();
+    static bool initDecoder();
     int play2d(const ccstd::string &filePath, bool loop, float volume);
     void setVolume(int audioID, float volume);
     void setLoop(int audioID, bool loop);


### PR DESCRIPTION
Re: #

### Changelog

* 原生 Audio 存在一个设计缺陷：当 OpenAL 不可用时，会使用这个 `sAudioEngineImpl = nullptr` 指针直接调用 `getPCMHeader()、getOriginalPCMBuffer()` 导致程序崩溃
* 现在按照以下三种情况修复：


| 情况 | 处理 |
| ----- | ----- |
| OpenAL 可用且已初始化 | 直接复用 `sAudioEngineImpl` ，无额外开销 |
| OpenAL 可用但尚未初始化 | `lazyInit()` 触发完整初始化，行为与改动前完全一致 |
| OpenAL 不可用 | `lazyInit()`  失败后降级到 `sDecoderImpl` ，PCM 解码依然正常 |

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
