### PR TITLE
fix(SRP): use lightIdx instead of loop index l in GPU instancing forw…

### DIFF
--- a/cocos/rendering/render-additive-light-queue.ts
+++ b/cocos/rendering/render-additive-light-queue.ts
@@ -219,12 +219,14 @@ export class RenderAdditiveLightQueue {
     public gatherLightPasses (camera: Camera, cmdBuff: CommandBuffer, passLayout = 'default'): void {
         this.clear();
 
-        const validPunctualLights = this._pipeline.pipelineSceneData.validPunctualLights;
-        this._bindForwardAddLight(validPunctualLights, passLayout);
-        if (!validPunctualLights.length) { return; }
-
         this._updateUBOs(camera, cmdBuff);
         this._updateLightDescriptorSet(camera, cmdBuff);
+
+        const validPunctualLights = this._pipeline.pipelineSceneData.validPunctualLights;
+        if (!validPunctualLights.length) { return; }
+
+        this._bindForwardAddLight(validPunctualLights, passLayout);
+
         // only for instanced and batched, no light culling applied
         for (let l = 0; l < validPunctualLights.length; l++) {
             const light = validPunctualLights[l];
@@ -465,7 +467,7 @@ export class RenderAdditiveLightQueue {
             }
             Color.toArray(this._shadowUBO, shadowInfo.shadowColor, UBOShadowEnum.SHADOW_COLOR_OFFSET);
 
-            globalDSManager.update();
+            descriptorSet.update();
 
             cmdBuff.updateBuffer(descriptorSet.getBuffer(UBOShadow.BINDING)!, this._shadowUBO.buffer, this._shadowUBO.byteLength);
         }

--- a/cocos/rendering/render-additive-light-queue.ts
+++ b/cocos/rendering/render-additive-light-queue.ts
@@ -196,7 +196,7 @@ export class RenderAdditiveLightQueue {
 
             this._lightCulling(model, validPunctualLights);
 
-            if (!_lightIndices.length && validPunctualLights.length > 0) { continue; }
+            if (!_lightIndices.length) { continue; }
 
             for (let j = 0; j < subModels.length; j++) {
                 const lightPassIdx = _lightPassIndices[j];
@@ -220,14 +220,11 @@ export class RenderAdditiveLightQueue {
         this.clear();
 
         const validPunctualLights = this._pipeline.pipelineSceneData.validPunctualLights;
-        if (!validPunctualLights.length) {
-            this._bindForwardAddLight(validPunctualLights, passLayout);
-            return;
-        }
+        this._bindForwardAddLight(validPunctualLights, passLayout);
+        if (!validPunctualLights.length) { return; }
 
         this._updateUBOs(camera, cmdBuff);
         this._updateLightDescriptorSet(camera, cmdBuff);
-        this._bindForwardAddLight(validPunctualLights, passLayout);
         // only for instanced and batched, no light culling applied
         for (let l = 0; l < validPunctualLights.length; l++) {
             const light = validPunctualLights[l];
@@ -374,9 +371,6 @@ export class RenderAdditiveLightQueue {
                 this._shadowUBO[UBOShadowEnum.SHADOW_LIGHT_PACKING_NBIAS_NULL_INFO_OFFSET + 1] = packing;
                 this._shadowUBO[UBOShadowEnum.SHADOW_LIGHT_PACKING_NBIAS_NULL_INFO_OFFSET + 2] = 0.0;
                 this._shadowUBO[UBOShadowEnum.SHADOW_LIGHT_PACKING_NBIAS_NULL_INFO_OFFSET + 3] = 0.0;
-
-                // Reserve sphere light shadow interface
-                Color.toArray(this._shadowUBO, shadowInfo.shadowColor, UBOShadowEnum.SHADOW_COLOR_OFFSET);
                 break;
             }
             case LightType.SPOT: {
@@ -441,8 +435,6 @@ export class RenderAdditiveLightQueue {
                 this._shadowUBO[UBOShadowEnum.SHADOW_PROJ_INFO_OFFSET + 2] = 1.0 / matShadowProj.m00;
                 this._shadowUBO[UBOShadowEnum.SHADOW_PROJ_INFO_OFFSET + 3] = 1.0 / matShadowProj.m05;
 
-                Color.toArray(this._shadowUBO, shadowInfo.shadowColor, UBOShadowEnum.SHADOW_COLOR_OFFSET);
-
                 // Spot light sampler binding
                 if (shadowFrameBufferMap.has(light)) {
                     const texture = shadowFrameBufferMap.get(light)?.colorTextures[0];
@@ -467,15 +459,15 @@ export class RenderAdditiveLightQueue {
                 this._shadowUBO[UBOShadowEnum.SHADOW_LIGHT_PACKING_NBIAS_NULL_INFO_OFFSET + 1] = packing;
                 this._shadowUBO[UBOShadowEnum.SHADOW_LIGHT_PACKING_NBIAS_NULL_INFO_OFFSET + 2] = 0.0;
                 this._shadowUBO[UBOShadowEnum.SHADOW_LIGHT_PACKING_NBIAS_NULL_INFO_OFFSET + 3] = 0.0;
-
-                // Reserve point light shadow interface
-                Color.toArray(this._shadowUBO, shadowInfo.shadowColor, UBOShadowEnum.SHADOW_COLOR_OFFSET);
                 break;
             }
             default:
             }
+            Color.toArray(this._shadowUBO, shadowInfo.shadowColor, UBOShadowEnum.SHADOW_COLOR_OFFSET);
+
             globalDSManager.update();
-            cmdBuff.updateBuffer(descriptorSet.getBuffer(UBOShadow.BINDING)!, this._shadowUBO);
+
+            cmdBuff.updateBuffer(descriptorSet.getBuffer(UBOShadow.BINDING)!, this._shadowUBO.buffer, this._shadowUBO.byteLength);
         }
     }
 
@@ -631,6 +623,6 @@ export class RenderAdditiveLightQueue {
             }
         }
 
-        cmdBuff.updateBuffer(this._lightBuffer, this._lightBufferData);
+        cmdBuff.updateBuffer(this._lightBuffer, this._lightBufferData.buffer as ArrayBuffer, this._lightBufferData.byteLength);
     }
 }

--- a/cocos/rendering/render-additive-light-queue.ts
+++ b/cocos/rendering/render-additive-light-queue.ts
@@ -243,6 +243,7 @@ export class RenderAdditiveLightQueue {
     public recordCommandBuffer (device: Device, renderPass: RenderPass, cmdBuff: CommandBuffer): void {
         const globalDSManager: GlobalDSManager = this._pipeline.globalDSManager;
         for (let j = 0; j < this._instancedQueues.length; ++j) {
+            if (!this._instancedQueues[j]) { continue; }
             const light = this._instancedLightPassPool.lights[j];
             _dynamicOffsets[0] = this._instancedLightPassPool.dynamicOffsets[j];
             const descriptorSet = globalDSManager.getOrCreateDescriptorSet(light);
@@ -318,11 +319,11 @@ export class RenderAdditiveLightQueue {
             if (((visibility & model.node.layer) === model.node.layer)) {
                 switch (batchingScheme) {
                 case BatchingSchemes.INSTANCING: {
-                    const buffer = pass.getInstancedBuffer(l);
+                    const buffer = pass.getInstancedBuffer(lightIdx);
                     buffer.merge(subModel, lightPassIdx);
-                    buffer.dynamicOffsets[0] = this._lightBufferStride;
-                    if (!this._instancedQueues[l]) { this._instancedQueues[l] = new RenderInstancedQueue(); }
-                    this._instancedQueues[l].queue.add(buffer);
+                    buffer.dynamicOffsets[0] = this._lightBufferStride * lightIdx;
+                    if (!this._instancedQueues[lightIdx]) { this._instancedQueues[lightIdx] = new RenderInstancedQueue(); }
+                    this._instancedQueues[lightIdx].queue.add(buffer);
                 } break;
                 default:
                     lp!.lights.push(light);

--- a/cocos/rendering/render-additive-light-queue.ts
+++ b/cocos/rendering/render-additive-light-queue.ts
@@ -322,7 +322,10 @@ export class RenderAdditiveLightQueue {
                     const buffer = pass.getInstancedBuffer(lightIdx);
                     buffer.merge(subModel, lightPassIdx);
                     buffer.dynamicOffsets[0] = this._lightBufferStride * lightIdx;
-                    if (!this._instancedQueues[lightIdx]) { this._instancedQueues[lightIdx] = new RenderInstancedQueue(); }
+                    if (this._instancedQueues.length <= lightIdx || !this._instancedQueues[lightIdx]) {
+                        this._instancedQueues.length = lightIdx + 1;
+                        this._instancedQueues[lightIdx] = new RenderInstancedQueue();
+                    }
                     this._instancedQueues[lightIdx].queue.add(buffer);
                 } break;
                 default:

--- a/native/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
+++ b/native/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
@@ -110,12 +110,11 @@ void RenderAdditiveLightQueue::gatherLightPasses(const scene::Camera *camera, gf
 
     clear();
 
-    _validPunctualLights = _pipeline->getPipelineSceneData()->getValidPunctualLights();
-
-    if (_validPunctualLights.empty()) return;
-
     updateUBOs(camera, cmdBuffer);
     updateLightDescriptorSet(camera, cmdBuffer);
+
+    _validPunctualLights = _pipeline->getPipelineSceneData()->getValidPunctualLights();
+    if (_validPunctualLights.empty()) return;
 
     const auto &renderObjects = _pipeline->getPipelineSceneData()->getRenderObjects();
     for (const auto &renderObject : renderObjects) {

--- a/native/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
+++ b/native/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
@@ -164,11 +164,6 @@ void RenderAdditiveLightQueue::clear() {
         instancedQueue->clear();
     }
     _instancedQueues.clear();
-
-    for (auto lightPass : _lightPasses) {
-        lightPass.dynamicOffsets.clear();
-        lightPass.lights.clear();
-    }
     _lightPasses.clear();
 
     _instancedLightPass.dynamicOffsets.clear();
@@ -245,6 +240,7 @@ void RenderAdditiveLightQueue::updateUBOs(const scene::Camera *camera, gfx::Comm
 
     size_t offset = 0;
     if (validLightCount > _lightBufferCount) {
+        _firstLightBufferView->destroy();
         _lightBufferCount = nextPow2(static_cast<uint32_t>(validLightCount));
         _lightBuffer->resize(utils::toUint(_lightBufferStride * _lightBufferCount));
         _lightBufferData.resize(static_cast<size_t>(_lightBufferElementCount) * _lightBufferCount);
@@ -434,7 +430,7 @@ void RenderAdditiveLightQueue::updateLightDescriptorSet(const scene::Camera *cam
                 memcpy(_shadowUBO.data() + UBOShadow::MAT_LIGHT_VIEW_PROJ_OFFSET, matShadowViewProj.m, sizeof(matShadowViewProj));
 
                 // shadow info
-                float shadowNFLSInfos[4] = {0.1F, spotLight->getRange(), 0.0F, 0.0F};
+                float shadowNFLSInfos[4] = {0.01F, spotLight->getRange(), 0.0F, 0.0F};
                 memcpy(_shadowUBO.data() + UBOShadow::SHADOW_NEAR_FAR_LINEAR_SATURATION_INFO_OFFSET, &shadowNFLSInfos, sizeof(shadowNFLSInfos));
 
                 const auto &shadowSize = shadowInfo->getSize();
@@ -493,15 +489,17 @@ bool RenderAdditiveLightQueue::getLightPassIndex(const scene::Model *model, ccst
     bool hasValidLightPass = false;
 
     for (const auto &subModel : model->getSubModels()) {
-        int lightPassIndex = 0;
+        int lightPassIndex = -1; // use -1 to indicate no valid light pass found
+        int k = 0;
         for (const auto &pass : *(subModel->getPasses())) {
             if (pass->getPhase() == _phaseID) {
+                lightPassIndex = k;
                 hasValidLightPass = true;
                 break;
             }
-            ++lightPassIndex;
+            ++k;
         }
-        lightPassIndices->push_back(lightPassIndex);
+        lightPassIndices->push_back(static_cast<uint32_t>(lightPassIndex)); 
     }
 
     return hasValidLightPass;
@@ -519,7 +517,7 @@ void RenderAdditiveLightQueue::lightCulling(const scene::Model *model) {
                 isCulled = cullSpotLight(static_cast<const scene::SpotLight *>(light), model);
                 break;
             case scene::LightType::POINT:
-                isCulled = cullSphereLight(static_cast<const scene::SphereLight *>(light), model);
+                isCulled = cullPointLight(static_cast<const scene::PointLight *>(light), model);
                 break;
             case scene::LightType::RANGED_DIRECTIONAL:
                 isCulled = cullRangedDirLight(static_cast<const scene::RangedDirectionalLight *>(light), model);

--- a/native/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
+++ b/native/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
@@ -68,6 +68,7 @@ RenderAdditiveLightQueue::RenderAdditiveLightQueue(RenderPipeline *pipeline) : _
 void RenderAdditiveLightQueue::recordCommandBuffer(gfx::Device *device, scene::Camera *camera, gfx::RenderPass *renderPass, gfx::CommandBuffer *cmdBuffer) {
     const uint32_t offset = _pipeline->getPipelineUBO()->getCurrentCameraUBOOffset();
     for (uint32_t i = 0; i < _instancedQueues.size(); ++i) {
+        if (!this->_instancedQueues[i]) { continue; }
         const auto *light = _instancedLightPass.lights[i];
         _dynamicOffsets[0] = _instancedLightPass.dynamicOffsets[i];
         auto *globalDescriptorSet = _pipeline->getGlobalDSManager()->getOrCreateDescriptorSet(light);
@@ -212,13 +213,11 @@ void RenderAdditiveLightQueue::addRenderQueue(scene::SubModel *subModel, const s
         if ((visibility & model->getNode()->getLayer()) == model->getNode()->getLayer()) {
             switch (batchingScheme) {
                 case scene::BatchingSchemes::INSTANCING: {
-                    auto *buffer = pass->getInstancedBuffer(i);
+                    auto *buffer = pass->getInstancedBuffer(lightIdx);
                     buffer->merge(subModel, lightPassIdx);
-                    buffer->setDynamicOffset(0, _lightBufferStride);
-                    if (i >= _instancedQueues.size()) {
-                        _instancedQueues.emplace_back(ccnew RenderInstancedQueue());
-                    }
-                    _instancedQueues[i]->add(buffer);
+                    buffer->setDynamicOffset(0, _lightBufferStride * lightIdx);
+                    if (!_instancedQueues[lightIdx]) { _instancedQueues[lightIdx] = ccnew RenderInstancedQueue(); }
+                    _instancedQueues[lightIdx]->add(buffer);
                 } break;
                 case scene::BatchingSchemes::NONE: {
                     lightPass.lights.emplace_back(light);

--- a/native/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
+++ b/native/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
@@ -216,7 +216,10 @@ void RenderAdditiveLightQueue::addRenderQueue(scene::SubModel *subModel, const s
                     auto *buffer = pass->getInstancedBuffer(lightIdx);
                     buffer->merge(subModel, lightPassIdx);
                     buffer->setDynamicOffset(0, _lightBufferStride * lightIdx);
-                    if (!_instancedQueues[lightIdx]) { _instancedQueues[lightIdx] = ccnew RenderInstancedQueue(); }
+                    if (_instancedQueues.size() <= lightIdx || !_instancedQueues[lightIdx]) {
+                        _instancedQueues.resize(lightIdx + 1);
+                        _instancedQueues[lightIdx] = ccnew RenderInstancedQueue();
+                    }
                     _instancedQueues[lightIdx]->add(buffer);
                 } break;
                 case scene::BatchingSchemes::NONE: {


### PR DESCRIPTION
…ard-add light path

Re: #

### Changelog

* lightIdx = _lightIndices[l] 才是灯光在 validPunctualLights 里的真实索引。用 l 取 instanced buffer 会导致不同灯光抢同一个 buffer / 不同模型错配到错误灯光的 buffer。native 也是
* https://github.com/cocos/cocos-engine/issues/19170

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
