### PR TITLE
feat(2d): support pixelsToUnit in SpriteFrame.reset

### DIFF
--- a/cocos/2d/assets/sprite-frame.ts
+++ b/cocos/2d/assets/sprite-frame.ts
@@ -26,8 +26,8 @@
 */
 
 import { ccclass } from 'cc.decorator';
-import { EDITOR, NODEJS, TEST, BUILD } from 'internal:constants';
-import { Rect, Size, Vec2, Vec3, Vec4, cclegacy, errorID, warnID, js, v3, mat4, rect, v4, v2, size } from '../../core';
+import { EDITOR, NODEJS, TEST, BUILD, DEBUG } from 'internal:constants';
+import { Rect, Size, Vec2, Vec3, Vec4, cclegacy, errorID, warnID, warn, js, v3, mat4, rect, v4, v2, size } from '../../core';
 import { Asset } from '../../asset/assets/asset';
 import { TextureBase } from '../../asset/assets/texture-base';
 import { ImageAsset, ImageSource } from '../../asset/assets/image-asset';
@@ -132,6 +132,12 @@ export interface ISpriteFrameInitInfo {
      * 在图集中的精灵帧可能会被剔除透明像素以获得更高的空间利用李，剔除后的矩形尺寸比剪裁前更小，偏移量指的是从原始矩形的中心到剪裁后的矩形中心的距离。
      */
     offset?: Vec2;
+    /**
+     * @en Number of pixels corresponding to unit size in world space.
+     * @zh 世界空间中的单位大小对应的像素数量。
+     * @default 100
+     */
+    pixelsToUnit?: number;
     /**
      * @en Top side border for sliced 9 frame.
      * @zh 九宫格精灵帧的上边界。
@@ -815,6 +821,7 @@ export class SpriteFrame extends Asset {
     public reset (info?: ISpriteFrameInitInfo, clearData = false): void {
         const self = this;
         let calUV = false;
+        let shouldUpdateMesh = false;
         if (clearData) {
             self._originalSize.set(0, 0);
             self._rect.set(0, 0, 0, 0);
@@ -825,10 +832,24 @@ export class SpriteFrame extends Asset {
         }
 
         if (info) {
+            const pixelsToUnit = info.pixelsToUnit;
+            if (pixelsToUnit !== undefined && pixelsToUnit !== self._pixelsToUnit) {
+                let isValid = true;
+                if (DEBUG && (typeof pixelsToUnit !== 'number' || !Number.isFinite(pixelsToUnit) || pixelsToUnit <= 0)) {
+                    isValid = false;
+                    warn('SpriteFrame pixelsToUnit must be a finite number greater than 0.');
+                }
+                if (isValid) {
+                    self._pixelsToUnit = pixelsToUnit;
+                    shouldUpdateMesh = true;
+                }
+            }
+
             if (info.texture) {
                 self._rect.set(0, 0, info.texture.width, info.texture.height);
-                self._refreshTexture(info.texture);
+                self._refreshTexture(info.texture, false);
                 self.checkRect(self._texture);
+                shouldUpdateMesh = true;
             }
 
             if (info.originalSize) {
@@ -875,6 +896,9 @@ export class SpriteFrame extends Asset {
             self._calculateUV();
         }
         self._calcTrimmedBorder();
+        if (shouldUpdateMesh && self._mesh) {
+            self._updateMesh();
+        }
     }
 
     /**
@@ -1379,7 +1403,7 @@ export class SpriteFrame extends Asset {
         return sp;
     }
 
-    protected _refreshTexture (texture: TextureBase): void {
+    protected _refreshTexture (texture: TextureBase, updateMesh = true): void {
         const self = this;
         self._texture = texture;
         const tex = self._texture;
@@ -1404,7 +1428,7 @@ export class SpriteFrame extends Asset {
         }
 
         self._checkPackable();
-        if (self._mesh) {
+        if (updateMesh && self._mesh) {
             self._updateMesh();
         }
     }

--- a/tests/ui/sprite-frame.test.ts
+++ b/tests/ui/sprite-frame.test.ts
@@ -1,6 +1,7 @@
 import { SpriteFrame } from "../../cocos/2d";
 import { Texture2D } from "../../cocos/asset/assets";
 import { Rect, Size, Vec2 } from "../../exports/base";
+import { captureWarns } from "../utils/log-capture";
 
 test('spritefrom.get',()=>{
     let sp = new SpriteFrame;
@@ -146,4 +147,169 @@ test('spriteframe.clone', () => {
     sp_clone.texture.setFilters(Texture2D.Filter.NEAREST, Texture2D.Filter.NEAREST);
     // Textures are not deep copies.
     expect(sp_clone.texture === sp.texture).toEqual(true);
+});
+
+describe('SpriteFrame.reset pixelsToUnit', () => {
+    test('accepts pixelsToUnit', () => {
+        /// @case
+        /// 1. A runtime-created SpriteFrame is reset with a texture, rect, and pixelsToUnit.
+        /// 2. Mesh data is requested from the SpriteFrame.
+        /// @expect
+        /// The SpriteFrame stores the requested pixelsToUnit and creates mesh bounds in world units.
+        const texture = new Texture2D();
+        texture.reset({ width: 200, height: 100 });
+
+        const sp = new SpriteFrame();
+        sp.reset({
+            texture,
+            rect: new Rect(0, 0, 200, 100),
+            pixelsToUnit: 50,
+        });
+        sp.ensureMeshData();
+
+        const minPosition = sp.mesh!.struct.minPosition!;
+        const maxPosition = sp.mesh!.struct.maxPosition!;
+        expect(sp.pixelsToUnit).toBe(50);
+        expect(maxPosition.x - minPosition.x).toBeCloseTo(4);
+        expect(maxPosition.y - minPosition.y).toBeCloseTo(2);
+    });
+
+    test('preserves pixelsToUnit when omitted', () => {
+        /// @case
+        /// 1. A SpriteFrame is reset with a custom pixelsToUnit.
+        /// 2. The SpriteFrame is reset again without pixelsToUnit.
+        /// @expect
+        /// The existing pixelsToUnit is preserved for backwards-compatible partial resets.
+        const sp = new SpriteFrame();
+        sp.reset({ pixelsToUnit: 25 });
+        sp.reset({ rect: new Rect(0, 0, 10, 10) });
+
+        expect(sp.pixelsToUnit).toBe(25);
+    });
+
+    test('refreshes existing mesh when pixelsToUnit changes', () => {
+        /// @case
+        /// 1. A SpriteFrame creates mesh data with the default pixelsToUnit.
+        /// 2. The SpriteFrame is reset with a different pixelsToUnit.
+        /// @expect
+        /// Existing mesh data reflects the new world-unit scale.
+        const texture = new Texture2D();
+        texture.reset({ width: 200, height: 100 });
+
+        const sp = new SpriteFrame();
+        sp.reset({
+            texture,
+            rect: new Rect(0, 0, 200, 100),
+        });
+        sp.ensureMeshData();
+        expect(sp.mesh!.struct.maxPosition!.x - sp.mesh!.struct.minPosition!.x).toBeCloseTo(2);
+
+        sp.reset({ pixelsToUnit: 50 });
+
+        expect(sp.mesh!.struct.maxPosition!.x - sp.mesh!.struct.minPosition!.x).toBeCloseTo(4);
+        expect(sp.mesh!.struct.maxPosition!.y - sp.mesh!.struct.minPosition!.y).toBeCloseTo(2);
+    });
+
+    test('rebuilds existing mesh when pixelsToUnit changes while clearing data', () => {
+        /// @case
+        /// 1. A SpriteFrame has existing mesh data.
+        /// 2. It is reset with a new pixelsToUnit and clearData enabled.
+        /// @expect
+        /// The mesh is rebuilt from the cleared rect instead of scaling stale raw vertices.
+        const texture = new Texture2D();
+        texture.reset({ width: 200, height: 100 });
+
+        const sp = new SpriteFrame();
+        sp.reset({ texture });
+        sp.ensureMeshData();
+
+        sp.reset({ pixelsToUnit: 50 }, true);
+
+        const minPosition = sp.mesh!.struct.minPosition!;
+        const maxPosition = sp.mesh!.struct.maxPosition!;
+        expect(sp.pixelsToUnit).toBe(50);
+        expect(sp.rect.width).toBe(0);
+        expect(sp.rect.height).toBe(0);
+        expect(maxPosition.x - minPosition.x).toBe(0);
+        expect(maxPosition.y - minPosition.y).toBe(0);
+    });
+
+    test('refreshes existing mesh from the final texture, rect, and pixelsToUnit state', () => {
+        /// @case
+        /// 1. A SpriteFrame has existing mesh data.
+        /// 2. It is reset with a new texture, a sub-rect, and a new pixelsToUnit.
+        /// @expect
+        /// The refreshed mesh bounds use the final sub-rect and pixelsToUnit values.
+        const initialTexture = new Texture2D();
+        initialTexture.reset({ width: 64, height: 64 });
+        const nextTexture = new Texture2D();
+        nextTexture.reset({ width: 200, height: 100 });
+
+        const sp = new SpriteFrame();
+        sp.reset({ texture: initialTexture });
+        sp.ensureMeshData();
+
+        sp.reset({
+            texture: nextTexture,
+            rect: new Rect(10, 5, 50, 25),
+            pixelsToUnit: 25,
+        });
+
+        const minPosition = sp.mesh!.struct.minPosition!;
+        const maxPosition = sp.mesh!.struct.maxPosition!;
+        expect(maxPosition.x - minPosition.x).toBeCloseTo(2);
+        expect(maxPosition.y - minPosition.y).toBeCloseTo(1);
+    });
+
+    test('rebuilds existing mesh when rect and pixelsToUnit change', () => {
+        /// @case
+        /// 1. A SpriteFrame has existing mesh data for a full texture rect.
+        /// 2. It is reset with a smaller rect and a new pixelsToUnit without changing texture.
+        /// @expect
+        /// The refreshed mesh bounds use the new rect instead of scaling stale raw vertices.
+        const texture = new Texture2D();
+        texture.reset({ width: 200, height: 100 });
+
+        const sp = new SpriteFrame();
+        sp.reset({ texture });
+        sp.ensureMeshData();
+
+        sp.reset({
+            rect: new Rect(10, 5, 50, 25),
+            pixelsToUnit: 25,
+        });
+
+        const minPosition = sp.mesh!.struct.minPosition!;
+        const maxPosition = sp.mesh!.struct.maxPosition!;
+        expect(maxPosition.x - minPosition.x).toBeCloseTo(2);
+        expect(maxPosition.y - minPosition.y).toBeCloseTo(1);
+    });
+
+    test('warns and ignores invalid pixelsToUnit', () => {
+        /// @case
+        /// 1. A SpriteFrame has a valid pixelsToUnit.
+        /// 2. It is reset with invalid pixelsToUnit values and another valid field.
+        /// @expect
+        /// Each invalid value warns, preserves pixelsToUnit, and does not interrupt the rest of reset.
+        const sp = new SpriteFrame();
+        sp.reset({ pixelsToUnit: 25 });
+        const nextRect = new Rect(0, 0, 10, 10);
+        const warnWatcher = captureWarns();
+        const invalidPixelsToUnit = [0, -1, NaN, Infinity, -Infinity, '25' as unknown as number];
+
+        invalidPixelsToUnit.forEach((pixelsToUnit, index) => {
+            expect(() => sp.reset({
+                pixelsToUnit,
+                rect: index === 0 ? nextRect : undefined,
+            })).not.toThrow();
+            expect(sp.pixelsToUnit).toBe(25);
+        });
+
+        expect(sp.rect).toEqual(nextRect);
+        expect(warnWatcher.captured).toHaveLength(invalidPixelsToUnit.length);
+        warnWatcher.captured.forEach(([message]) => {
+            expect(message).toBe('SpriteFrame pixelsToUnit must be a finite number greater than 0.');
+        });
+        warnWatcher.stop();
+    });
 });


### PR DESCRIPTION
Re: #

This gives callers an opportunity to set pixels per unit when initializing a `SpriteFrame` through `reset()`, for example when creating sprite frames directly in tests. Unity's `Sprite.Create` similarly accepts a `pixelsPerUnit` argument at sprite creation time.

### Changelog

* Support setting `pixelsToUnit` through `SpriteFrame.reset()`.

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [x] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.