### PR TITLE
fix(web): detect SubFrame client size changes

### DIFF
--- a/pal/screen-adapter/web/screen-adapter.ts
+++ b/pal/screen-adapter/web/screen-adapter.ts
@@ -33,11 +33,6 @@ import legacyCC from '../../../predefine';
 import { checkPalIntegrity, withImpl } from '../../integrity-check';
 import { OS } from '../../system-info/enum-type';
 
-interface ICachedStyle {
-    width: string;
-    height: string;
-}
-
 const EVENT_TIMEOUT = EDITOR ? 5 : 200;
 const orientationMap: Record<ConfigOrientation, Orientation> = {
     auto: Orientation.AUTO,
@@ -178,8 +173,7 @@ class ScreenAdapter extends EventTarget {
     private _gameContainer?: HTMLDivElement;
     private _gameCanvas?: HTMLCanvasElement;
     private _isProportionalToFrame = false;
-    private _cachedFrameStyle: ICachedStyle = { width: '0px', height: '0px' };
-    private _cachedContainerStyle: ICachedStyle = { width: '0px', height: '0px' };
+    private _cachedWindowSizeInCssPixels = new Size(0, 0);
     private _cbToUpdateFrameBuffer?: () => void;
     private _supportFullScreen = false;
     private _touchEventName: string;
@@ -641,19 +635,13 @@ class ScreenAdapter extends EventTarget {
             containerStyle.height = '100%';
         }
 
-        // Cache Test
-        if (this._gameFrame
-            && (this._cachedFrameStyle.width !== this._gameFrame.style.width
-            || this._cachedFrameStyle.height !== this._gameFrame.style.height
-            || this._cachedContainerStyle.width !== this._gameContainer.style.width
-            || this._cachedContainerStyle.height !== this._gameContainer.style.height)) {
-            this.emit('window-resize', this.windowSize.width, this.windowSize.height);
-
-            // Update Cache
-            this._cachedFrameStyle.width = this._gameFrame.style.width;
-            this._cachedFrameStyle.height = this._gameFrame.style.height;
-            this._cachedContainerStyle.width = this._gameContainer.style.width;
-            this._cachedContainerStyle.height = this._gameContainer.style.height;
+        if (this._gameFrame) {
+            const windowSizeInCssPixels = this._windowSizeInCssPixels;
+            if (!this._cachedWindowSizeInCssPixels.equals(windowSizeInCssPixels)) {
+                this._cachedWindowSizeInCssPixels.set(windowSizeInCssPixels);
+                const dpr = this.devicePixelRatio;
+                this.emit('window-resize', windowSizeInCssPixels.width * dpr, windowSizeInCssPixels.height * dpr);
+            }
         }
     }
 }

--- a/tests/pal/screen-adapter.test.ts
+++ b/tests/pal/screen-adapter.test.ts
@@ -1,0 +1,72 @@
+describe('Web ScreenAdapter resize detection', () => {
+    it('emits one resize when the SubFrame client size changes without inline style changes', () => {
+        /// @case
+        /// 1. A SubFrame uses unchanged 100% inline dimensions.
+        /// 2. Its actual client size changes during a browser resize.
+        /// @expect
+        /// The new physical size is emitted exactly once, and duplicate resize events are ignored.
+        document.body.innerHTML = `
+            <div id="GameDiv" style="width: 100%; height: 100%;">
+                <div id="Cocos3dGameContainer">
+                    <canvas id="GameCanvas"></canvas>
+                </div>
+            </div>
+        `;
+
+        const gameFrame = document.getElementById('GameDiv') as HTMLDivElement;
+        let frameWidth = 800;
+        let frameHeight = 600;
+        Object.defineProperties(gameFrame, {
+            clientWidth: {
+                configurable: true,
+                get: (): number => frameWidth,
+            },
+            clientHeight: {
+                configurable: true,
+                get: (): number => frameHeight,
+            },
+        });
+
+        jest.resetModules();
+        jest.doMock('internal:constants', () => ({
+            ...jest.requireActual('../constants-for-test'),
+            TEST: false,
+        }), { virtual: true });
+        jest.doMock('pal/system-info', () => ({
+            systemInfo: {
+                isMobile: false,
+                os: '',
+            },
+        }), { virtual: true });
+
+        jest.isolateModules(() => {
+            const { screenAdapter } = require('../../pal/screen-adapter/web/screen-adapter') as
+                typeof import('../../pal/screen-adapter/web/screen-adapter');
+            screenAdapter.init({
+                configOrientation: 'auto',
+                exactFitScreen: false,
+                isHeadlessMode: false,
+            }, jest.fn());
+
+            const onWindowResize = jest.fn();
+            screenAdapter.on('window-resize', onWindowResize);
+
+            frameWidth = 640;
+            frameHeight = 360;
+            window.dispatchEvent(new Event('resize'));
+
+            const dpr = screenAdapter.devicePixelRatio;
+            expect(gameFrame.style.width).toBe('100%');
+            expect(gameFrame.style.height).toBe('100%');
+            expect(screenAdapter.windowSize.width).toBe(640 * dpr);
+            expect(screenAdapter.windowSize.height).toBe(360 * dpr);
+            expect(onWindowResize).toHaveBeenCalledTimes(1);
+            expect(onWindowResize.mock.calls[0].slice(0, 2)).toEqual([640 * dpr, 360 * dpr]);
+
+            window.dispatchEvent(new Event('resize'));
+            expect(onWindowResize).toHaveBeenCalledTimes(1);
+
+            screenAdapter.off('window-resize', onWindowResize);
+        });
+    });
+});


### PR DESCRIPTION
Re: #

### Changelog

* Fix Web/SubFrame resize detection when the effective frame size changes without an inline style change.

### Root Cause

`ScreenAdapter._updateContainer()` detected resize events by comparing the inline `width` and `height` strings of the game frame and container. When a SubFrame uses stable values such as `width: 100%` and `height: 100%`, resizing its embedding viewport changes `clientWidth` and `clientHeight` while those inline style strings remain unchanged. As a result, `screen.windowSize` could reflect the new DOM size, but no `window-resize` event was emitted and dependent view/framebuffer state remained stale.

### Reproduction

1. Initialize the Web ScreenAdapter with a `GameDiv` whose inline width and height remain `100%`.
2. Resize the embedding viewport so the frame's effective client size changes, for example from `800x600` to `640x360`.
3. Observe that `screenAdapter.windowSize` reports the new size, but the `window-resize` event is not emitted.
4. The view adaptation and framebuffer resize path therefore does not run.

### Solution

Cache and compare the effective CSS window size after container layout is updated. When it changes, update the cache before emitting `window-resize`, and derive the event payload from the same CSS-size sample multiplied by the current device pixel ratio. This keeps the existing DPR-only, fullscreen, and orientation mechanisms unchanged and does not add a public API.

### Testing

* Added a black-box Web ScreenAdapter regression test covering a SubFrame whose client size changes while its inline styles stay unchanged.
* Verified the resize event is emitted exactly once with the new physical size and is not repeated for an unchanged size.
* `node ./node_modules/jest/bin/jest.js tests/pal/screen-adapter.test.ts tests/core/view.test.ts --runInBand`
* `node ./node_modules/typescript/bin/tsc --noEmit`

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.
