### PR TITLE
fix(legacy): custom attribute that set format error

### DIFF
--- a/native/cocos/3d/misc/CreateMesh.cpp
+++ b/native/cocos/3d/misc/CreateMesh.cpp
@@ -185,7 +185,11 @@ Mesh::ICreateInfo MeshUtils::createMeshInfo(const IGeometry &geometry, const ccs
 
     if (geometry.customAttributes.has_value()) {
         for (const auto &ca : geometry.customAttributes.value()) {
-            const auto &info = gfx::GFX_FORMAT_INFOS[static_cast<uint32_t>(attr->format)];
+            if (ca.values.empty()) {
+                CC_LOG_ERROR("Custom attribute %s has no values, skipped.", ca.attr.name.c_str());
+                continue;
+            }
+            const auto &info = gfx::GFX_FORMAT_INFOS[static_cast<uint32_t>(ca.attr.format)];
             attributes.emplace_back(ca.attr);
             vertCount = std::max(vertCount, static_cast<uint32_t>(std::floor(ca.values.size() / info.count)));
             channels.emplace_back(Channel{stride, ca.values, ca.attr});

--- a/native/cocos/3d/misc/CreateMesh.cpp
+++ b/native/cocos/3d/misc/CreateMesh.cpp
@@ -186,7 +186,7 @@ Mesh::ICreateInfo MeshUtils::createMeshInfo(const IGeometry &geometry, const ccs
     if (geometry.customAttributes.has_value()) {
         for (const auto &ca : geometry.customAttributes.value()) {
             if (ca.values.empty()) {
-                CC_LOG_ERROR("Custom attribute %s has no values, skipped.", ca.attr.name.c_str());
+                CC_LOG_WARNING("Custom attribute %s has no values, skipped.", ca.attr.name.c_str());
                 continue;
             }
             const auto &info = gfx::GFX_FORMAT_INFOS[static_cast<uint32_t>(ca.attr.format)];


### PR DESCRIPTION
Re: #

### Changelog

* 错误地引用上一个 `attr` 指针替换为正确的 `ca.attr.format`, 并删除了残留的错误注释
* https://github.com/cocos/cocos-engine/issues/19071

与之前 bug 的本质区别：

|  | 标准属性模块(position/normal/uv...) | 旧版(customAttributes 块) |
| ----- | ----- | ----- |
| 进入前`attr`重置 | √ attr = nullptr | × 无重置，沿用上一块的值 |
| `attr`赋值来源 | 当前属性从(geometry.attributes 或 defAttrs[N]) | *错误地*仍指向上一个标准属性 |
| `info`是否正确 | √ | × |

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
