### PR TITLE
Fix(legacy): only DEFAULT layer has lighting

### DIFF
--- a/cocos/rendering/planar-shadow-queue.ts
+++ b/cocos/rendering/planar-shadow-queue.ts
@@ -29,7 +29,6 @@ import { PipelineStateManager } from './pipeline-state-manager';
 import { Model, Camera, SubModel } from '../render-scene/scene';
 import { RenderInstancedQueue } from './render-instanced-queue';
 import { ShadowType } from '../render-scene/scene/shadows';
-import { Layers } from '../scene-graph/layers';
 import { PipelineRuntime } from './custom/pipeline';
 import { BatchingSchemes, Pass } from '../render-scene/core/pass';
 import { getPhaseID } from './pass-phase';
@@ -83,18 +82,16 @@ export class PlanarShadowQueue {
 
         const scene = camera.scene!;
         const frustum = camera.frustum;
-        const shadowVisible =  (camera.visibility & Layers.BitMask.DEFAULT) !== 0;
+        const shadowVisible = camera.visibility !== 0;
         if (!scene.mainLight || !shadowVisible) { return; }
 
         const models = scene.models;
-        const visibility = camera.visibility;
         for (let i = 0; i < models.length; i++) {
             const model = models[i];
             if (scene.isCulledByLod(camera, model)) {
                 continue;
             }
-            if (model.enabled && model.node && model.castShadow
-                && (model.node && ((visibility & model.node.layer) === model.node.layer))) {
+            if (model.enabled && model.node && model.castShadow) {
                 this._castModels.push(model);
             }
         }

--- a/cocos/rendering/render-additive-light-queue.ts
+++ b/cocos/rendering/render-additive-light-queue.ts
@@ -320,7 +320,8 @@ export class RenderAdditiveLightQueue {
             const lightIdx = _lightIndices[l];
             const light = validPunctualLights[lightIdx];
             const visibility = light.visibility;
-            if (((visibility & model.node.layer) === model.node.layer)) {
+            if (((visibility & model.node.layer) === model.node.layer)
+                || (visibility & model.visFlags)) {
                 switch (batchingScheme) {
                 case BatchingSchemes.INSTANCING: {
                     const buffer = pass.getInstancedBuffer(lightIdx);

--- a/cocos/rendering/scene-culling.ts
+++ b/cocos/rendering/scene-culling.ts
@@ -195,8 +195,8 @@ export function sceneCulling (sceneData: PipelineSceneData, pipelineUBO: Pipelin
                 csmLayerObjects.push(getRenderObject(model, camera));
             }
 
-            if (model.node && ((visibility & model.node.layer) === model.node.layer)
-                 || (visibility & model.visFlags)) {
+            if ((model.node && ((visibility & model.node.layer) === model.node.layer))
+                || (visibility & model.visFlags)) {
                 // frustum culling
                 if (model.worldBounds && !geometry.intersect.aabbFrustum(model.worldBounds, camera.frustum)) {
                     return;

--- a/native/cocos/renderer/pipeline/PlanarShadowQueue.cpp
+++ b/native/cocos/renderer/pipeline/PlanarShadowQueue.cpp
@@ -59,7 +59,7 @@ void PlanarShadowQueue::gatherShadowPasses(scene::Camera *camera, gfx::CommandBu
     }
 
     const auto *scene = camera->getScene();
-    const bool shadowVisible = camera->getVisibility() & static_cast<uint32_t>(LayerList::DEFAULT);
+    const bool shadowVisible = camera->getVisibility() != 0;
     if (!scene->getMainLight() || !shadowVisible) {
         return;
     }

--- a/native/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
+++ b/native/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
@@ -208,7 +208,8 @@ void RenderAdditiveLightQueue::addRenderQueue(scene::SubModel *subModel, const s
         const auto lightIdx = _lightIndices[i];
         const auto *light = _validPunctualLights[lightIdx];
         const auto visibility = light->getVisibility();
-        if ((visibility & model->getNode()->getLayer()) == model->getNode()->getLayer()) {
+        if (((visibility & model->getNode()->getLayer()) == model->getNode()->getLayer()) ||
+            (visibility & static_cast<uint32_t>(model->getVisFlags()))) {
             switch (batchingScheme) {
                 case scene::BatchingSchemes::INSTANCING: {
                     auto *buffer = pass->getInstancedBuffer(lightIdx);


### PR DESCRIPTION
Re: #

### Changelog

* Fix: also check model->getVisFlags() so 2D batch models (which store layer in visFlags)
* can also receive punctual light illumination.
* https://github.com/cocos/cocos-engine/issues/17880

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
