### PR TITLE
feat(2d): add animated image (animated WebP) playback support

### DIFF
--- a/@types/pal/image-decoder.d.ts
+++ b/@types/pal/image-decoder.d.ts
@@ -1,0 +1,26 @@
+declare module 'pal/image-decoder' {
+    /**
+     * @en Whether the current platform backend can decode the given mime type natively (without WASM).
+     * When it returns `false`, `createAnimatedDecoder` will fall back to the bundled libwebp WASM backend.
+     * @zh 当前平台后端能否原生（不借助 WASM）解码给定 mime 类型。
+     * 返回 `false` 时，`createAnimatedDecoder` 会回退到自带的 libwebp WASM 后端。
+     *
+     * @param mime The image mime type, e.g. `image/webp`.
+     */
+    export function isNativeAnimatedSupported (mime: string): boolean;
+
+    /**
+     * @en Creates an animated image decoder for the given encoded bytes. It prefers the platform native
+     * path and transparently falls back to the bundled libwebp WASM backend when native decoding is
+     * unavailable or fails.
+     * @zh 为给定的编码字节创建动画图片解码器。优先走平台原生路径，当原生解码不可用或失败时，
+     * 透明回退到自带的 libwebp WASM 后端。
+     *
+     * @param bytes The raw encoded image bytes (e.g. the content of a `.webp` file).
+     * @param mime The image mime type, e.g. `image/webp`.
+     */
+    export function createAnimatedDecoder (
+        bytes: Uint8Array,
+        mime: string,
+    ): Promise<import('pal/image-decoder/type').IAnimatedImageDecoder>;
+}

--- a/cc.config.json
+++ b/cc.config.json
@@ -174,6 +174,10 @@
         "video": {
             "modules": ["video"]
         },
+        "animated-image": {
+            "modules": ["animated-image"],
+            "dependentModules": ["2d"]
+        },
         "xr": {
             "modules": ["xr"],
             "overrideConstants": {
@@ -389,7 +393,8 @@
                 "pal/input": "pal/input/web/index.ts",
                 "pal/env": "pal/env/web/env.ts",
                 "pal/pacer": "pal/pacer/pacer-web.ts",
-                "pal/wasm": "pal/wasm/wasm-web.ts"
+                "pal/wasm": "pal/wasm/wasm-web.ts",
+                "pal/image-decoder": "pal/image-decoder/web/image-decoder-web.ts"
             }
         },
         {
@@ -403,7 +408,8 @@
                 "pal/input": "pal/input/native/index.ts",
                 "pal/env": "pal/env/native/env.ts",
                 "pal/pacer": "pal/pacer/pacer-native.ts",
-                "pal/wasm": "pal/wasm/wasm-native.ts"
+                "pal/wasm": "pal/wasm/wasm-native.ts",
+                "pal/image-decoder": "pal/image-decoder/native/image-decoder-native.ts"
             }
         },
         {
@@ -417,7 +423,8 @@
                 "pal/input": "pal/input/minigame/index.ts",
                 "pal/env": "pal/env/minigame/env.ts",
                 "pal/pacer": "pal/pacer/pacer-minigame.ts",
-                "pal/wasm": "pal/wasm/wasm-minigame.ts"
+                "pal/wasm": "pal/wasm/wasm-minigame.ts",
+                "pal/image-decoder": "pal/image-decoder/minigame/image-decoder-minigame.ts"
             }
         },
         {
@@ -431,7 +438,8 @@
                 "pal/input": "pal/input/minigame/index.ts",
                 "pal/env": "pal/env/runtime/env.ts",
                 "pal/pacer": "pal/pacer/pacer-minigame.ts",
-                "pal/wasm": "pal/wasm/wasm-minigame.ts"
+                "pal/wasm": "pal/wasm/wasm-minigame.ts",
+                "pal/image-decoder": "pal/image-decoder/minigame/image-decoder-minigame.ts"
             }
         },
         {
@@ -445,7 +453,8 @@
                 "pal/input": "pal/input/nodejs/index.ts",
                 "pal/env": "pal/env/nodejs/env.ts",
                 "pal/pacer": "pal/pacer/pacer-nodejs.ts",
-                "pal/wasm": "pal/wasm/wasm-nodejs.ts"
+                "pal/wasm": "pal/wasm/wasm-nodejs.ts",
+                "pal/image-decoder": "pal/image-decoder/nodejs/image-decoder-nodejs.ts"
             }
         },
         {

--- a/cocos/2d/animated-image/animated-image-player.ts
+++ b/cocos/2d/animated-image/animated-image-player.ts
@@ -1,0 +1,316 @@
+/*
+ Copyright (c) 2023 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+import { createAnimatedDecoder, isNativeAnimatedSupported } from 'pal/image-decoder';
+import type { IAnimatedImageDecoder, IDecodedFrame } from 'pal/image-decoder/type';
+import { DEBUG } from 'internal:constants';
+import { Texture2D } from '../../asset/assets/texture-2d';
+import { PixelFormat } from '../../asset/assets/asset-enum';
+import { SpriteFrame } from '../assets/sprite-frame';
+import { warn } from '../../core/platform/debug';
+
+/**
+ * @en Playback state of an [[AnimatedImagePlayer]].
+ * @zh [[AnimatedImagePlayer]] 的播放状态。
+ */
+export enum AnimatedImagePlayerState {
+    /** @en Not yet loaded. @zh 尚未加载完成。 */
+    INIT,
+    /** @en Playing. @zh 正在播放。 */
+    PLAYING,
+    /** @en Paused. @zh 已暂停。 */
+    PAUSED,
+    /** @en Stopped (reset to frame 0). @zh 已停止（回到第 0 帧）。 */
+    STOPPED,
+}
+
+/**
+ * @en
+ * Low-level player for animated images (animated WebP). It owns a decoder (WebCodecs / minigame / WASM,
+ * selected per platform), a reusable [[Texture2D]] whose pixels are refreshed in place every frame, and a
+ * [[SpriteFrame]] you can bind to any [[Sprite]]. Drive it by calling [[tick]] with the frame delta time.
+ *
+ * The texture object identity never changes across frames — only its GPU pixels are overwritten via
+ * `Texture2D.uploadData`, so no dirty notification to the renderer is required.
+ * @zh
+ * 动画图片（动画 WebP）的底层播放器。内部持有一个解码器（按平台选择 WebCodecs / 小游戏 / WASM）、
+ * 一个每帧原地刷新像素的可复用 [[Texture2D]]，以及一个可绑定到任意 [[Sprite]] 的 [[SpriteFrame]]。
+ * 通过每帧调用 [[tick]] 并传入帧间隔时间来驱动播放。
+ *
+ * 纹理对象在整个播放过程中身份不变——每帧只通过 `Texture2D.uploadData` 覆盖其 GPU 像素，
+ * 因此无需向渲染器发送任何脏标记。
+ */
+export class AnimatedImagePlayer {
+    /**
+     * @en Creates a player from raw encoded image bytes.
+     * @zh 从原始编码图片字节创建播放器。
+     * @param bytes @en The raw encoded bytes (e.g. a `.webp` file content). @zh 原始编码字节（如 `.webp` 文件内容）。
+     * @param mime @en The mime type, defaults to `image/webp`. @zh mime 类型，默认为 `image/webp`。
+     */
+    public static async create (bytes: Uint8Array, mime = 'image/webp'): Promise<AnimatedImagePlayer> {
+        const decoder = await createAnimatedDecoder(bytes, mime);
+        return new AnimatedImagePlayer(decoder);
+    }
+
+    /**
+     * @en Whether the current platform can decode `mime` natively (informational; the player always works
+     * because it falls back to WASM internally).
+     * @zh 当前平台能否原生解码 `mime`（仅供参考，播放器始终可用，内部会回退到 WASM）。
+     */
+    public static isNativeSupported (mime = 'image/webp'): boolean {
+        return isNativeAnimatedSupported(mime);
+    }
+
+    /**
+     * @en
+     * Debug/test switch. When `true`, the Web backend bypasses the native WebCodecs `ImageDecoder` and
+     * forces the bundled libwebp WASM fallback, so you can smoke-test the fallback chain on platforms that
+     * have a native decoder (e.g. Chrome). No effect on platforms that already use WASM. Must be set before
+     * a player is created.
+     * @zh
+     * 调试/测试开关。为 `true` 时，Web 后端会跳过原生 WebCodecs `ImageDecoder`，强制走自带的 libwebp WASM
+     * 兜底路径，便于在有原生解码器的平台（如 Chrome）冒烟测试兜底链路。对本就走 WASM 的平台无影响。
+     * 需在创建播放器之前设置。
+     */
+    public static get forceWasmDecoder (): boolean {
+        return (globalThis as { __forceWebpWasmDecoder?: boolean }).__forceWebpWasmDecoder === true;
+    }
+    public static set forceWasmDecoder (value: boolean) {
+        (globalThis as { __forceWebpWasmDecoder?: boolean }).__forceWebpWasmDecoder = value;
+    }
+
+    private _decoder: IAnimatedImageDecoder;
+    private _texture: Texture2D;
+    private _spriteFrame: SpriteFrame;
+    private _state = AnimatedImagePlayerState.STOPPED;
+    private _loop = true;
+    private _currentFrame = 0;
+    private _accumMs = 0;
+    private _duration = 0;
+    /** cache of decoded frames, indexed by frame index */
+    private _frameCache: (IDecodedFrame | undefined)[];
+    /** duration(ms) of each frame; -1 means unknown until decoded */
+    private _frameDurations: number[];
+    private _pendingDecode = false;
+    private _destroyed = false;
+
+    private constructor (decoder: IAnimatedImageDecoder) {
+        this._decoder = decoder;
+        this._frameCache = new Array<IDecodedFrame | undefined>(decoder.frameCount);
+        this._frameDurations = new Array<number>(decoder.frameCount).fill(-1);
+
+        const texture = new Texture2D();
+        texture.reset({
+            width: decoder.width,
+            height: decoder.height,
+            format: PixelFormat.RGBA8888,
+            mipmapLevel: 1,
+        });
+        this._texture = texture;
+
+        const spriteFrame = new SpriteFrame();
+        spriteFrame.texture = texture;
+        // Live textures must never be moved into the dynamic atlas, otherwise only the first frame is copied.
+        spriteFrame.packable = false;
+        this._spriteFrame = spriteFrame;
+
+        // decode and present frame 0 immediately so the sprite is not blank before the first tick.
+        void this._presentFrame(0);
+    }
+
+    /**
+     * @en The output sprite frame. Bind it to a `Sprite`; it is refreshed in place every frame.
+     * @zh 输出的精灵帧。将其绑定到 `Sprite`；它会每帧原地刷新。
+     */
+    get spriteFrame (): SpriteFrame {
+        return this._spriteFrame;
+    }
+
+    /**
+     * @en The underlying reusable texture.
+     * @zh 底层复用的纹理。
+     */
+    get texture (): Texture2D {
+        return this._texture;
+    }
+
+    /** @en Total frame count. @zh 总帧数。 */
+    get frameCount (): number {
+        return this._decoder.frameCount;
+    }
+
+    /** @en Index of the currently presented frame. @zh 当前显示帧的索引。 */
+    get currentFrame (): number {
+        return this._currentFrame;
+    }
+
+    /** @en Current playback state. @zh 当前播放状态。 */
+    get state (): AnimatedImagePlayerState {
+        return this._state;
+    }
+
+    /**
+     * @en Total duration of the animation in milliseconds. Only known for frames already decoded; grows as
+     * frames are visited. It is exact once every frame has been decoded at least once.
+     * @zh 动画总时长（毫秒）。仅统计已解码帧，随帧的访问而增长；当所有帧都至少解码过一次后即为精确值。
+     */
+    get duration (): number {
+        return this._duration;
+    }
+
+    /** @en Whether the animation loops. @zh 动画是否循环。 */
+    get loop (): boolean {
+        return this._loop;
+    }
+    set loop (value: boolean) {
+        this._loop = value;
+    }
+
+    /**
+     * @en Starts playing from the current frame. Restarts from frame 0 if stopped.
+     * @zh 从当前帧开始播放。若已停止则从第 0 帧重新开始。
+     */
+    public play (): void {
+        if (this._destroyed) { return; }
+        if (this._state === AnimatedImagePlayerState.STOPPED) {
+            this._currentFrame = 0;
+            this._accumMs = 0;
+            void this._presentFrame(0);
+        }
+        this._state = AnimatedImagePlayerState.PLAYING;
+    }
+
+    /** @en Pauses playback on the current frame. @zh 在当前帧暂停播放。 */
+    public pause (): void {
+        if (this._state === AnimatedImagePlayerState.PLAYING) {
+            this._state = AnimatedImagePlayerState.PAUSED;
+        }
+    }
+
+    /** @en Resumes from a paused state. @zh 从暂停状态继续播放。 */
+    public resume (): void {
+        if (this._state === AnimatedImagePlayerState.PAUSED) {
+            this._state = AnimatedImagePlayerState.PLAYING;
+        }
+    }
+
+    /** @en Stops and resets to frame 0. @zh 停止并回到第 0 帧。 */
+    public stop (): void {
+        this._state = AnimatedImagePlayerState.STOPPED;
+        this._currentFrame = 0;
+        this._accumMs = 0;
+        void this._presentFrame(0);
+    }
+
+    /**
+     * @en Jumps to a specific frame (does not change the playing/paused state).
+     * @zh 跳转到指定帧（不改变播放/暂停状态）。
+     */
+    public seekToFrame (index: number): void {
+        if (this._destroyed) { return; }
+        const clamped = Math.max(0, Math.min(index, this.frameCount - 1));
+        this._currentFrame = clamped;
+        this._accumMs = 0;
+        void this._presentFrame(clamped);
+    }
+
+    /**
+     * @en Advances playback by `dt` seconds. Call once per game frame while playing.
+     * @zh 按 `dt` 秒推进播放。播放时每游戏帧调用一次。
+     * @param dt @en Delta time in seconds. @zh 帧间隔时间，单位为秒。
+     */
+    public tick (dt: number): void {
+        if (this._destroyed || this._state !== AnimatedImagePlayerState.PLAYING || this.frameCount <= 1) {
+            return;
+        }
+        this._accumMs += dt * 1000;
+        // advance as many frames as the elapsed time covers (handles low frame rates / long dt).
+        let guard = this.frameCount;
+        while (guard-- > 0) {
+            const frameDur = this._frameDurations[this._currentFrame];
+            // duration not known yet (frame still decoding); wait for it rather than spinning.
+            if (frameDur < 0) {
+                void this._presentFrame(this._currentFrame);
+                break;
+            }
+            if (this._accumMs < frameDur) {
+                break;
+            }
+            this._accumMs -= frameDur;
+            const next = this._currentFrame + 1;
+            if (next >= this.frameCount) {
+                if (this._loop) {
+                    this._currentFrame = 0;
+                } else {
+                    this._currentFrame = this.frameCount - 1;
+                    this._state = AnimatedImagePlayerState.STOPPED;
+                    break;
+                }
+            } else {
+                this._currentFrame = next;
+            }
+            void this._presentFrame(this._currentFrame);
+        }
+    }
+
+    /** @en Releases the decoder, texture and sprite frame. @zh 释放解码器、纹理与精灵帧。 */
+    public destroy (): void {
+        if (this._destroyed) { return; }
+        this._destroyed = true;
+        this._state = AnimatedImagePlayerState.STOPPED;
+        this._decoder.destroy();
+        this._frameCache.length = 0;
+        this._spriteFrame.destroy();
+        this._texture.destroy();
+    }
+
+    private async _presentFrame (index: number): Promise<void> {
+        if (this._destroyed) { return; }
+        let frame = this._frameCache[index];
+        if (!frame) {
+            if (this._pendingDecode) { return; }
+            this._pendingDecode = true;
+            try {
+                frame = await this._decoder.decodeFrame(index);
+            } catch (e) {
+                if (DEBUG) {
+                    warn(`AnimatedImagePlayer failed to decode frame ${index}: ${e}`);
+                }
+                return;
+            } finally {
+                this._pendingDecode = false;
+            }
+            if (this._destroyed) { return; }
+            this._frameCache[index] = frame;
+            if (this._frameDurations[index] < 0) {
+                this._frameDurations[index] = frame.duration;
+                this._duration += frame.duration;
+            }
+        }
+        // only upload if this is still the frame we want to show.
+        if (index === this._currentFrame) {
+            this._texture.uploadData(frame.data, 0);
+        }
+    }
+}

--- a/cocos/2d/animated-image/index.ts
+++ b/cocos/2d/animated-image/index.ts
@@ -1,0 +1,26 @@
+/*
+ Copyright (c) 2023 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+export { AnimatedImagePlayer, AnimatedImagePlayerState } from './animated-image-player';
+export { AnimatedImage, AnimatedImageSourceType } from '../components/animated-image';

--- a/cocos/2d/components/animated-image.ts
+++ b/cocos/2d/components/animated-image.ts
@@ -1,0 +1,358 @@
+/*
+ Copyright (c) 2023 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+import { ccclass, menu, executeInEditMode, requireComponent, tooltip, type, serializable, range, slide, visible } from 'cc.decorator';
+import { NODEJS } from 'internal:constants';
+import { Component } from '../../scene-graph';
+import { Sprite } from './sprite';
+import { BufferAsset } from '../../asset/assets/buffer-asset';
+import { ImageAsset } from '../../asset/assets/image-asset';
+import { assetManager } from '../../asset/asset-manager';
+import { ccenum, warn } from '../../core';
+import { AnimatedImagePlayer } from '../animated-image/animated-image-player';
+
+/**
+ * @en The source type of an [[AnimatedImage]].
+ * @zh [[AnimatedImage]] 的来源类型。
+ */
+export enum AnimatedImageSourceType {
+    /** @en A local `BufferAsset` holding the encoded bytes. @zh 持有编码字节的本地 `BufferAsset`。 */
+    LOCAL = 0,
+    /** @en A remote URL fetched at runtime. @zh 运行时拉取的远程 URL。 */
+    REMOTE = 1,
+    /**
+     * @en An `ImageAsset` imported the default way (the original `.webp` file is preserved). Recommended:
+     * import the webp as a normal image and drag it onto the component.
+     * @zh 按默认方式导入的图片资源 `ImageAsset`（原始 `.webp` 文件会被保留）。推荐用法：把 webp 当普通图片
+     * 导入后直接拖到组件上。
+     */
+    IMAGE = 2,
+}
+ccenum(AnimatedImageSourceType);
+
+/**
+ * @en
+ * A component that plays an animated image (animated WebP) on the [[Sprite]] of the same node. It wraps the
+ * low-level [[AnimatedImagePlayer]]: it loads the encoded bytes (from a local [[BufferAsset]] or a remote
+ * URL), drives frame advancement every update, and feeds the refreshed sprite frame to the sibling `Sprite`.
+ * @zh
+ * 在同节点的 [[Sprite]] 上播放动画图片（动画 WebP）的组件。它封装了底层的 [[AnimatedImagePlayer]]：
+ * 加载编码字节（来自本地 [[BufferAsset]] 或远程 URL），每帧推进播放，并把刷新后的精灵帧交给同节点的 `Sprite`。
+ */
+@ccclass('cc.AnimatedImage')
+@menu('2D/AnimatedImage')
+@requireComponent(Sprite)
+@executeInEditMode
+export class AnimatedImage extends Component {
+    @serializable
+    protected _sourceType = AnimatedImageSourceType.IMAGE;
+    @type(BufferAsset)
+    @serializable
+    protected _clip: BufferAsset | null = null;
+    @type(ImageAsset)
+    @serializable
+    protected _image: ImageAsset | null = null;
+    @serializable
+    protected _remoteURL = '';
+    @serializable
+    protected _playOnAwake = true;
+    @serializable
+    protected _loop = true;
+    @serializable
+    protected _playbackRate = 1;
+
+    protected _player: AnimatedImagePlayer | null = null;
+    protected _sprite: Sprite | null = null;
+    /** guards against a stale async load overwriting a newer source */
+    protected _loadToken = 0;
+
+    /**
+     * @en The source type: LOCAL (a `BufferAsset`) or REMOTE (a URL).
+     * @zh 来源类型：LOCAL（`BufferAsset`）或 REMOTE（URL）。
+     */
+    @type(AnimatedImageSourceType)
+    @tooltip('i18n:animated_image.sourceType')
+    get sourceType (): AnimatedImageSourceType {
+        return this._sourceType;
+    }
+    set sourceType (val) {
+        if (this._sourceType !== val) {
+            this._sourceType = val;
+            this._reload();
+        }
+    }
+
+    /**
+     * @en The local buffer asset holding the encoded animated image bytes.
+     * @zh 持有动画图片编码字节的本地缓冲资源。
+     */
+    @type(BufferAsset)
+    @tooltip('i18n:animated_image.clip')
+    @visible(function (this: AnimatedImage) { return this._sourceType === AnimatedImageSourceType.LOCAL; })
+    get clip (): BufferAsset | null {
+        return this._clip;
+    }
+    set clip (val) {
+        if (this._clip !== val) {
+            this._clip = val;
+            this._reload();
+        }
+    }
+
+    /**
+     * @en The image asset (a webp imported the default way) to play. The original encoded bytes are
+     * fetched via its `nativeUrl`. This is the recommended source: import a webp as a normal image and
+     * assign it here.
+     * @zh 要播放的图片资源（按默认方式导入的 webp）。会通过其 `nativeUrl` 获取原始编码字节。推荐用法：
+     * 把 webp 当普通图片导入后赋值到这里。
+     */
+    @type(ImageAsset)
+    @tooltip('i18n:animated_image.image')
+    @visible(function (this: AnimatedImage) { return this._sourceType === AnimatedImageSourceType.IMAGE; })
+    get image (): ImageAsset | null {
+        return this._image;
+    }
+    set image (val) {
+        if (this._image !== val) {
+            this._image = val;
+            this._reload();
+        }
+    }
+
+    /**
+     * @en The remote URL of the animated image (used when `sourceType` is REMOTE).
+     * @zh 动画图片的远程 URL（当 `sourceType` 为 REMOTE 时使用）。
+     */
+    @tooltip('i18n:animated_image.remoteURL')
+    @visible(function (this: AnimatedImage) { return this._sourceType === AnimatedImageSourceType.REMOTE; })
+    get remoteURL (): string {
+        return this._remoteURL;
+    }
+    set remoteURL (val: string) {
+        if (this._remoteURL !== val) {
+            this._remoteURL = val;
+            this._reload();
+        }
+    }
+
+    /**
+     * @en Whether to start playing automatically after the image is loaded.
+     * @zh 图片加载完成后是否自动开始播放。
+     */
+    @tooltip('i18n:animated_image.playOnAwake')
+    get playOnAwake (): boolean {
+        return this._playOnAwake;
+    }
+    set playOnAwake (value) {
+        this._playOnAwake = value;
+    }
+
+    /**
+     * @en Whether the animation loops.
+     * @zh 动画是否循环播放。
+     */
+    @tooltip('i18n:animated_image.loop')
+    get loop (): boolean {
+        return this._loop;
+    }
+    set loop (value) {
+        this._loop = value;
+        if (this._player) {
+            this._player.loop = value;
+        }
+    }
+
+    /**
+     * @en The playback rate. The value range is [0.0, 10.0].
+     * @zh 播放速率，取值区间为 [0.0, 10.0]。
+     */
+    @slide
+    @range([0.0, 10.0, 0.1])
+    @tooltip('i18n:animated_image.playbackRate')
+    get playbackRate (): number {
+        return this._playbackRate;
+    }
+    set playbackRate (value: number) {
+        this._playbackRate = value;
+    }
+
+    public static SourceType = AnimatedImageSourceType;
+
+    /** @en Total frame count, or 0 before loaded. @zh 总帧数，加载前为 0。 */
+    get frameCount (): number {
+        return this._player ? this._player.frameCount : 0;
+    }
+
+    /** @en Index of the currently displayed frame. @zh 当前显示帧的索引。 */
+    get currentFrame (): number {
+        return this._player ? this._player.currentFrame : 0;
+    }
+
+    /** @en Total duration in milliseconds (see [[AnimatedImagePlayer.duration]]). @zh 总时长（毫秒）。 */
+    get duration (): number {
+        return this._player ? this._player.duration : 0;
+    }
+
+    /** @en Whether it is currently playing. @zh 当前是否正在播放。 */
+    get isPlaying (): boolean {
+        return !!this._player && this._player.state === 1; // PLAYING
+    }
+
+    /** @en The underlying player, or null before loaded. @zh 底层播放器，加载前为 null。 */
+    get player (): AnimatedImagePlayer | null {
+        return this._player;
+    }
+
+    public onLoad (): void {
+        this._sprite = this.getComponent(Sprite);
+        if (NODEJS) {
+            return;
+        }
+        this._reload();
+    }
+
+    public onEnable (): void {
+        if (this._player && this._playOnAwake) {
+            this._player.play();
+        }
+    }
+
+    public onDisable (): void {
+        if (this._player) {
+            this._player.pause();
+        }
+    }
+
+    public onDestroy (): void {
+        this._loadToken++;
+        this._destroyPlayer();
+        this._sprite = null;
+    }
+
+    public update (dt: number): void {
+        if (this._player) {
+            this._player.tick(dt * this._playbackRate);
+        }
+    }
+
+    /**
+     * @en Starts playing. Restarts from frame 0 if stopped, resumes if paused.
+     * @zh 开始播放。若已停止则从第 0 帧重新开始，若已暂停则继续播放。
+     */
+    public play (): void {
+        this._player?.play();
+    }
+
+    /** @en Resumes a paused animation. @zh 继续播放已暂停的动画。 */
+    public resume (): void {
+        this._player?.resume();
+    }
+
+    /** @en Pauses on the current frame. @zh 在当前帧暂停。 */
+    public pause (): void {
+        this._player?.pause();
+    }
+
+    /** @en Stops and resets to frame 0. @zh 停止并回到第 0 帧。 */
+    public stop (): void {
+        this._player?.stop();
+    }
+
+    /** @en Jumps to the given frame index. @zh 跳转到给定帧索引。 */
+    public seekToFrame (index: number): void {
+        this._player?.seekToFrame(index);
+    }
+
+    protected _reload (): void {
+        if (!this.node) {
+            return;
+        }
+        const token = ++this._loadToken;
+        this._destroyPlayer();
+
+        const onBytes = (bytes: Uint8Array | null): void => {
+            // a newer reload happened, or the component was destroyed, while we were loading.
+            if (token !== this._loadToken || !this.node || !bytes) {
+                return;
+            }
+            AnimatedImagePlayer.create(bytes).then((player) => {
+                if (token !== this._loadToken || !this.node) {
+                    player.destroy();
+                    return;
+                }
+                player.loop = this._loop;
+                this._player = player;
+                if (this._sprite) {
+                    this._sprite.spriteFrame = player.spriteFrame;
+                }
+                if (this._playOnAwake && this.enabledInHierarchy) {
+                    player.play();
+                }
+            }).catch((e) => {
+                warn(`AnimatedImage failed to create player: ${e}`);
+            });
+        };
+
+        if (this._sourceType === AnimatedImageSourceType.REMOTE) {
+            if (!this._remoteURL) {
+                return;
+            }
+            this._downloadFromUrl(this._remoteURL, onBytes);
+        } else if (this._sourceType === AnimatedImageSourceType.IMAGE) {
+            // A webp imported the default way keeps its original file; nativeUrl points at it (same-origin
+            // in preview, so no CORS). Fetch the raw bytes and decode them ourselves.
+            const url = this._image ? this._image.nativeUrl : '';
+            if (!url) {
+                return;
+            }
+            this._downloadFromUrl(url, onBytes);
+        } else {
+            if (!this._clip || !this._clip.validate()) {
+                return;
+            }
+            onBytes(new Uint8Array(this._clip.buffer()));
+        }
+    }
+
+    /** Downloads raw bytes from a URL and hands them to `onBytes` (used by REMOTE and IMAGE sources). */
+    protected _downloadFromUrl (url: string, onBytes: (bytes: Uint8Array | null) => void): void {
+        assetManager.downloader.download(url, url, '.bin', {}, (err, data: ArrayBuffer) => {
+            if (err) {
+                warn(`AnimatedImage failed to download ${url}: ${err}`);
+                return;
+            }
+            onBytes(new Uint8Array(data));
+        });
+    }
+
+    protected _destroyPlayer (): void {
+        if (this._player) {
+            this._player.destroy();
+            this._player = null;
+        }
+        if (this._sprite) {
+            this._sprite.spriteFrame = null;
+        }
+    }
+}

--- a/editor/engine-features/render-config.json
+++ b/editor/engine-features/render-config.json
@@ -317,6 +317,16 @@
             "cmakeConfig": "USE_VIDEO",
             "enginePlugin": true
         },
+        "animated-image": {
+            "default": true,
+            "label": "i18n:ENGINE.features.animated_image.label",
+            "description": "i18n:ENGINE.features.animated_image.description",
+            "enginePlugin": false,
+            "category": "2d",
+            "dependencies": [
+                "2d"
+            ]
+        },
         "webview": {
             "default": true,
             "label": "i18n:ENGINE.features.webview.label",

--- a/editor/i18n/en/localization.js
+++ b/editor/i18n/en/localization.js
@@ -654,6 +654,15 @@ module.exports = link(mixin({
         videoPlayerEvent:
             "The video player's callback, it will be triggered when certain event occurs, <br>like: playing, paused, stopped and completed.",
     },
+    animated_image: {
+        sourceType: 'Source of the image: IMAGE references an image asset imported the default way (recommended), REMOTE is a remote URL, LOCAL is a local BufferAsset.',
+        image: 'The image asset to play (an animated WebP imported as a normal image). Import the webp as an image and drag it here.',
+        clip: 'A local BufferAsset holding the encoded bytes (used when the source is LOCAL).',
+        remoteURL: 'The remote URL of the animated image (used when the source is REMOTE; watch out for CORS).',
+        playOnAwake: 'Whether to start playing automatically after the image is loaded?',
+        loop: 'Whether the animation loops.',
+        playbackRate: 'The playback rate (0.0 ~ 10.0).',
+    },
     webview: {
         url: 'A given URL to be loaded by the Webview, <br>it should have a http or https prefix.',
         webviewEvents: "The Webview's event callback , <br>it will be triggered when certain Webview event occurs.",
@@ -1044,6 +1053,10 @@ module.exports = link(mixin({
         video: {
             label: "Video",
             description: "Video playing support.",
+        },
+        animated_image: {
+            label: "Animated Image",
+            description: "Animated image (animated WebP) playback support.",
         },
         webview: {
             label: "Web View",

--- a/editor/i18n/zh/localization.js
+++ b/editor/i18n/zh/localization.js
@@ -639,6 +639,15 @@ module.exports = link(mixin({
         stayOnBottom: '永远在游戏视图最底层（这个属性只有在 Web 平台上有效果。注意：具体效果无法保证一致，跟各个浏览器是否支持与限制有关）',
         videoPlayerEvent: '视频播放回调函数，该回调函数会在特定情况被触发，比如播放中，暂时，停止和完成播放。',
     },
+    animated_image: {
+        sourceType: '图片来源：IMAGE 表示引用一个按默认方式导入的图片资源（推荐），REMOTE 表示远程 URL，LOCAL 表示本地 BufferAsset。',
+        image: '要播放的图片资源（按默认方式导入的动画 WebP）。把 webp 当普通图片导入后拖到这里即可。',
+        clip: '持有编码字节的本地 BufferAsset（LOCAL 来源时使用）。',
+        remoteURL: '动画图片的远程 URL（REMOTE 来源时使用，注意跨域 CORS）。',
+        playOnAwake: '图片加载完成后是否自动开始播放？',
+        loop: '动画是否循环播放。',
+        playbackRate: '播放速率（0.0 ~ 10.0）。',
+    },
     webview: {
         url: '指定一个 URL 地址，这个地址以 http 或者 https 开头，请填写一个有效的 URL 地址。',
         webviewEvents: 'Webview 的回调事件，当网页加载过程中，加载完成后或者加载出错时都会回调此函数',
@@ -1022,6 +1031,10 @@ module.exports = link(mixin({
         video: {
             label: "视频",
             description: "视频播放支持。",
+        },
+        animated_image: {
+            label: "动画图片",
+            description: "动画图片（动画 WebP）播放支持。",
         },
         webview: {
             label: "Web View",

--- a/exports/animated-image.ts
+++ b/exports/animated-image.ts
@@ -1,0 +1,26 @@
+/*
+ Copyright (c) 2023 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated engine source code (the "Software"), a limited,
+ worldwide, royalty-free, non-assignable, revocable and non-exclusive license
+ to use Cocos Creator solely to develop games on your target platforms. You shall
+ not use Cocos Creator software for developing other software or tools that's
+ used for developing games. You are not granted to publish, distribute,
+ sublicense, and/or sell copies of Cocos Creator.
+
+ The software or tools in this License Agreement are licensed, not sold.
+ Xiamen Yaji Software Co., Ltd. reserves all rights not expressly granted to you.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+export * from '../cocos/2d/animated-image';

--- a/pal/image-decoder/minigame/image-decoder-minigame.ts
+++ b/pal/image-decoder/minigame/image-decoder-minigame.ts
@@ -1,0 +1,41 @@
+/*
+ Copyright (c) 2023 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+import { checkPalIntegrity, withImpl } from '../../integrity-check';
+import type { IAnimatedImageDecoder } from '../type';
+import { createWasmDecoder } from '../wasm/webp-wasm-decoder';
+
+// Minigame platforms (WeChat, ByteDance, etc.) expose only a single-frame image path (`wx.createImage`),
+// which cannot walk animated webp frames. So the native path is disabled here and the multi-frame case is
+// served by the bundled libwebp WASM backend. When a specific minigame later exposes a real per-frame
+// decode API, enable it here (probe + return `true`) without touching the upper layers.
+export function isNativeAnimatedSupported (mime: string): boolean {
+    return false;
+}
+
+export function createAnimatedDecoder (bytes: Uint8Array, mime: string): Promise<IAnimatedImageDecoder> {
+    return createWasmDecoder(bytes);
+}
+
+checkPalIntegrity<typeof import('pal/image-decoder')>(withImpl<typeof import('./image-decoder-minigame')>());

--- a/pal/image-decoder/native/image-decoder-native.ts
+++ b/pal/image-decoder/native/image-decoder-native.ts
@@ -1,0 +1,39 @@
+/*
+ Copyright (c) 2023 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+import { checkPalIntegrity, withImpl } from '../../integrity-check';
+import type { IAnimatedImageDecoder } from '../type';
+import { createWasmDecoder } from '../wasm/webp-wasm-decoder';
+
+// Native platforms currently reuse the bundled libwebp WASM backend. A future C++ libwebp multi-frame
+// binding can replace this by returning `true` here and creating a native-backed decoder.
+export function isNativeAnimatedSupported (mime: string): boolean {
+    return false;
+}
+
+export function createAnimatedDecoder (bytes: Uint8Array, mime: string): Promise<IAnimatedImageDecoder> {
+    return createWasmDecoder(bytes);
+}
+
+checkPalIntegrity<typeof import('pal/image-decoder')>(withImpl<typeof import('./image-decoder-native')>());

--- a/pal/image-decoder/nodejs/image-decoder-nodejs.ts
+++ b/pal/image-decoder/nodejs/image-decoder-nodejs.ts
@@ -1,0 +1,38 @@
+/*
+ Copyright (c) 2023 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+import { checkPalIntegrity, withImpl } from '../../integrity-check';
+import type { IAnimatedImageDecoder } from '../type';
+import { createWasmDecoder } from '../wasm/webp-wasm-decoder';
+
+// Node.js (headless / server) reuses the bundled libwebp WASM backend.
+export function isNativeAnimatedSupported (mime: string): boolean {
+    return false;
+}
+
+export function createAnimatedDecoder (bytes: Uint8Array, mime: string): Promise<IAnimatedImageDecoder> {
+    return createWasmDecoder(bytes);
+}
+
+checkPalIntegrity<typeof import('pal/image-decoder')>(withImpl<typeof import('./image-decoder-nodejs')>());

--- a/pal/image-decoder/type.ts
+++ b/pal/image-decoder/type.ts
@@ -1,0 +1,81 @@
+/*
+ Copyright (c) 2023 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+/**
+ * @en A single decoded frame of an animated image.
+ * @zh 动画图片解码出的单帧数据。
+ */
+export interface IDecodedFrame {
+    /**
+     * @en Pixel data in RGBA8888 layout, top-down (row 0 is the top of the image).
+     * Its length is always `width * height * 4`.
+     * @zh RGBA8888 排布的像素数据，自上而下（第 0 行为图像顶部），长度恒为 `width * height * 4`。
+     */
+    data: Uint8Array;
+    /**
+     * @en Display duration of this frame, in milliseconds.
+     * @zh 该帧的显示时长，单位为毫秒。
+     */
+    duration: number;
+}
+
+/**
+ * @en The unified animated image decoder interface. Each platform backend (WebCodecs, minigame, WASM)
+ * implements it so the upper player class stays platform agnostic.
+ * @zh 统一的动画图片解码器接口。各平台后端（WebCodecs、小游戏、WASM）都实现它，
+ * 使上层播放器类与平台无关。
+ */
+export interface IAnimatedImageDecoder {
+    /**
+     * @en Pixel width of every frame.
+     * @zh 每帧的像素宽度。
+     */
+    readonly width: number;
+    /**
+     * @en Pixel height of every frame.
+     * @zh 每帧的像素高度。
+     */
+    readonly height: number;
+    /**
+     * @en Total frame count of the animation.
+     * @zh 动画的总帧数。
+     */
+    readonly frameCount: number;
+    /**
+     * @en Loop count declared by the file. `0` means loop forever.
+     * @zh 文件声明的循环次数。`0` 表示无限循环。
+     */
+    readonly loopCount: number;
+    /**
+     * @en Lazily decodes the frame at `index` and returns its RGBA data. Backends may cache internally.
+     * @zh 惰性解码 `index` 处的帧并返回其 RGBA 数据。后端内部可自行缓存。
+     * @param index @en Frame index, in range [0, frameCount). @zh 帧索引，取值范围 [0, frameCount)。
+     */
+    decodeFrame (index: number): Promise<IDecodedFrame>;
+    /**
+     * @en Releases all resources held by the decoder (WASM handles, VideoFrame caches, etc.).
+     * @zh 释放解码器持有的所有资源（WASM 句柄、VideoFrame 缓存等）。
+     */
+    destroy (): void;
+}

--- a/pal/image-decoder/wasm/webp-wasm-decoder.ts
+++ b/pal/image-decoder/wasm/webp-wasm-decoder.ts
@@ -1,0 +1,191 @@
+/*
+ Copyright (c) 2023 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+import { instantiateWasm, ensureWasmModuleReady } from 'pal/wasm';
+import { DEBUG } from 'internal:constants';
+import { warn } from '../../../cocos/core/platform/debug';
+import type { IAnimatedImageDecoder, IDecodedFrame } from '../type';
+
+// This is the bundled fallback backend. It drives the libwebp `WebPAnimDecoder` compiled to WASM,
+// vendored from the MIT-licensed `webpxmux` package (which embeds BSD-licensed libwebp). The glue
+// (`webpxmux.js`) and the binary (`webpxmux.wasm`) live under `native/external/emscripten/webp/`
+// and are loaded through the engine's `external:` protocol + `pal/wasm`, exactly like the spine /
+// box2d / meshopt WASM modules.
+//
+// `decodeFrames(dataPtr, dataSize)` demuxes + decodes the whole animation in one call and returns a
+// pointer to a flattened byte-stream (FBS) laid out as `uint32` cells:
+//   [0] frameCount (dup), [1] frameCount, [2] width, [3] height, [4] loopCount, [5] bgColor,
+//   then per frame: [duration(ms), isKeyframe, w*h RGBA pixels...].
+// Each pixel `uint32` reads as 0xRRGGBBAA (libwebp decodes to MODE_RGBA, then webpxmux byte-swaps so
+// the value is intuitive), so we serialize it big-endian into R,G,B,A bytes for RGBA8888 upload.
+
+const FBS_HEADER = 6;         // uint32 cells before the first frame
+const FBS_FRAME_HEADER = 2;   // uint32 cells (duration, isKeyframe) before each frame's pixels
+
+interface WebpXMuxModule {
+    cwrap (ident: string, returnType: string, argTypes: string[]): (...args: number[]) => number;
+    _malloc (size: number): number;
+    _free (ptr: number): void;
+    // NOTE: HEAPU8/HEAPU32 must be re-read after any allocation — the underlying ArrayBuffer is
+    // replaced (detached) when emscripten grows its linear memory.
+    HEAPU8: Uint8Array;
+    decodeFrames?: (dataPtr: number, dataSize: number) => number;
+}
+
+type WebpXMuxFactory = (moduleOptions: {
+    instantiateWasm (
+        importObject: WebAssembly.Imports,
+        receiveInstance: (instance: WebAssembly.Instance, module: WebAssembly.Module) => void,
+    ): void;
+}) => Promise<WebpXMuxModule>;
+
+let modulePromise: Promise<WebpXMuxModule> | null = null;
+
+function loadModule (): Promise<WebpXMuxModule> {
+    if (!modulePromise) {
+        modulePromise = ensureWasmModuleReady().then(() => Promise.all([
+            import('external:emscripten/webp/webpxmux.js'),
+            import('external:emscripten/webp/webpxmux.wasm'),
+        ])).then(([{ default: factory }, { default: wasmUrl }]) => (factory as WebpXMuxFactory)({
+            instantiateWasm (importObject, receiveInstance): void {
+                // NOTE: the Promise returned by the instantiateWasm hook can't be awaited by emscripten.
+                instantiateWasm(wasmUrl as string, importObject).then((result) => {
+                    receiveInstance(result.instance, result.module);
+                }).catch((e) => {
+                    if (DEBUG) {
+                        warn(`Failed to instantiate the animated webp wasm module: ${e}`);
+                    }
+                });
+            },
+        })).then((mod) => {
+            mod.decodeFrames = mod.cwrap('decodeFrames', 'number', ['number', 'number']);
+            return mod;
+        }).catch((e) => {
+            // reset so a later attempt can retry (e.g. after the wasm subpackage is downloaded)
+            modulePromise = null;
+            throw e;
+        });
+    }
+    return modulePromise;
+}
+
+class WebpWasmDecoder implements IAnimatedImageDecoder {
+    public readonly width: number;
+    public readonly height: number;
+    public readonly frameCount: number;
+    public readonly loopCount: number;
+
+    private _frames: IDecodedFrame[];
+
+    constructor (width: number, height: number, loopCount: number, frames: IDecodedFrame[]) {
+        this.width = width;
+        this.height = height;
+        this.frameCount = frames.length;
+        this.loopCount = loopCount;
+        this._frames = frames;
+    }
+
+    public decodeFrame (index: number): Promise<IDecodedFrame> {
+        // webpxmux decodes the whole animation up front, so this is a cache lookup.
+        if (index < 0 || index >= this._frames.length) {
+            return Promise.reject(new Error(`frame index ${index} out of range [0, ${this._frames.length})`));
+        }
+        return Promise.resolve(this._frames[index]);
+    }
+
+    public destroy (): void {
+        this._frames = [];
+    }
+}
+
+function decodeAllFrames (mod: WebpXMuxModule, bytes: Uint8Array): WebpWasmDecoder {
+    const size = bytes.byteLength;
+    const inPtr = mod._malloc(size);
+    if (!inPtr) {
+        throw new Error('failed to allocate wasm memory for webp bytes');
+    }
+    // fresh view: HEAPU8 may point at a stale (detached) buffer after the malloc above grew memory.
+    new Uint8Array(mod.HEAPU8.buffer, inPtr, size).set(bytes);
+
+    const bsPtr = mod.decodeFrames!(inPtr, size);
+    mod._free(inPtr);
+    if (bsPtr < 0) {
+        throw new Error(`libwebp failed to decode the animated webp (code ${bsPtr})`);
+    }
+
+    // Read back the flattened byte-stream. No further allocation happens here, so a single view is safe.
+    const heap = mod.HEAPU8.buffer;
+    const u32 = new Uint32Array(heap);
+    const base = bsPtr >>> 2;
+    const frameCount = u32[base + 1];
+    const width = u32[base + 2];
+    const height = u32[base + 3];
+    const loopCount = u32[base + 4];
+
+    const pixelCount = width * height;
+    const frameStride = FBS_FRAME_HEADER + pixelCount; // in uint32 cells
+    const frames: IDecodedFrame[] = new Array(frameCount);
+    for (let i = 0; i < frameCount; ++i) {
+        const f = base + FBS_HEADER + i * frameStride;
+        const duration = u32[f];
+        const pixels = f + FBS_FRAME_HEADER;
+        const data = new Uint8Array(pixelCount * 4);
+        for (let p = 0; p < pixelCount; ++p) {
+            const v = u32[pixels + p]; // 0xRRGGBBAA
+            const o = p * 4;
+            data[o] = (v >>> 24) & 0xff;      // R
+            data[o + 1] = (v >>> 16) & 0xff;  // G
+            data[o + 2] = (v >>> 8) & 0xff;   // B
+            data[o + 3] = v & 0xff;           // A
+        }
+        frames[i] = { data, duration };
+    }
+    mod._free(bsPtr);
+
+    return new WebpWasmDecoder(width, height, loopCount, frames);
+}
+
+/**
+ * @en Creates an animated image decoder backed by the bundled libwebp WASM module.
+ * @zh 使用自带的 libwebp WASM 模块创建动画图片解码器。
+ */
+export async function createWasmDecoder (bytes: Uint8Array): Promise<IAnimatedImageDecoder> {
+    const mod = await loadModule();
+    return decodeAllFrames(mod, bytes);
+}
+
+/**
+ * @en Whether the bundled WASM backend is expected to be usable on this platform.
+ * @zh 自带 WASM 后端在当前平台是否预期可用。
+ */
+export function isWasmDecoderSupported (): boolean {
+    try {
+        return typeof WebAssembly === 'object' && typeof WebAssembly.instantiate === 'function';
+    } catch (e) {
+        if (DEBUG) {
+            warn('WebAssembly is not available for the animated webp fallback decoder.');
+        }
+        return false;
+    }
+}

--- a/pal/image-decoder/web/image-decoder-web.ts
+++ b/pal/image-decoder/web/image-decoder-web.ts
@@ -1,0 +1,179 @@
+/*
+ Copyright (c) 2023 Xiamen Yaji Software Co., Ltd.
+
+ https://www.cocos.com/
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do so,
+ subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+import { DEBUG } from 'internal:constants';
+import { checkPalIntegrity, withImpl } from '../../integrity-check';
+import { warn } from '../../../cocos/core/platform/debug';
+import type { IAnimatedImageDecoder, IDecodedFrame } from '../type';
+import { createWasmDecoder, isWasmDecoderSupported } from '../wasm/webp-wasm-decoder';
+
+// Minimal ambient shape of the WebCodecs `ImageDecoder`/`VideoFrame` APIs. They are not yet part of
+// the TS lib the engine builds against, so we describe just what we use here and access them dynamically.
+interface WebImageDecoderTrack {
+    frameCount: number;
+    repetitionCount: number;
+}
+interface WebImageDecoderResult {
+    image: {
+        displayWidth: number;
+        displayHeight: number;
+        duration: number | null;   // microseconds
+        close (): void;
+    };
+    complete: boolean;
+}
+interface WebImageDecoder {
+    tracks: { ready: Promise<void>; selectedTrack: WebImageDecoderTrack | null };
+    decode (options: { frameIndex: number }): Promise<WebImageDecoderResult>;
+    close (): void;
+}
+interface WebImageDecoderCtor {
+    new (init: { data: BufferSource; type: string }): WebImageDecoder;
+    isTypeSupported (type: string): Promise<boolean>;
+}
+
+function getImageDecoderCtor (): WebImageDecoderCtor | undefined {
+    return (globalThis as { ImageDecoder?: WebImageDecoderCtor }).ImageDecoder;
+}
+
+class WebCodecsDecoder implements IAnimatedImageDecoder {
+    public readonly width: number;
+    public readonly height: number;
+    public readonly frameCount: number;
+    public readonly loopCount: number;
+
+    private _decoder: WebImageDecoder | null;
+    private _canvas: OffscreenCanvas | HTMLCanvasElement;
+    private _ctx: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D;
+
+    constructor (decoder: WebImageDecoder, width: number, height: number, frameCount: number, loopCount: number) {
+        this._decoder = decoder;
+        this.width = width;
+        this.height = height;
+        this.frameCount = frameCount;
+        this.loopCount = loopCount;
+        if (typeof OffscreenCanvas !== 'undefined') {
+            this._canvas = new OffscreenCanvas(width, height);
+        } else {
+            const canvas = document.createElement('canvas');
+            canvas.width = width;
+            canvas.height = height;
+            this._canvas = canvas;
+        }
+        this._ctx = this._canvas.getContext('2d', { willReadFrequently: true }) as CanvasRenderingContext2D;
+    }
+
+    public async decodeFrame (index: number): Promise<IDecodedFrame> {
+        if (!this._decoder) {
+            throw new Error('animated webp decoder has been destroyed');
+        }
+        const result = await this._decoder.decode({ frameIndex: index });
+        const videoFrame = result.image;
+        try {
+            // VideoFrame is drawable; read back its pixels as RGBA8888.
+            this._ctx.drawImage(videoFrame as unknown as CanvasImageSource, 0, 0);
+            const imageData = this._ctx.getImageData(0, 0, this.width, this.height);
+            const data = new Uint8Array(imageData.data.buffer.slice(0));
+            // VideoFrame.duration is in microseconds; convert to milliseconds.
+            const duration = videoFrame.duration != null ? videoFrame.duration / 1000 : 0;
+            return { data, duration };
+        } finally {
+            videoFrame.close();
+        }
+    }
+
+    public destroy (): void {
+        if (this._decoder) {
+            this._decoder.close();
+            this._decoder = null;
+        }
+    }
+}
+
+export function isNativeAnimatedSupported (mime: string): boolean {
+    return typeof getImageDecoderCtor() !== 'undefined';
+}
+
+// Debug/test switch: set `globalThis.__forceWebpWasmDecoder = true` (or `AnimatedImagePlayer.forceWasmDecoder = true`)
+// to bypass the native WebCodecs path and exercise the bundled WASM fallback chain on platforms that
+// do have a native decoder (e.g. Chrome). Reading an unset global is free, so this stays zero-cost in production.
+function shouldForceWasm (): boolean {
+    return (globalThis as { __forceWebpWasmDecoder?: boolean }).__forceWebpWasmDecoder === true;
+}
+
+async function tryCreateNative (bytes: Uint8Array, mime: string): Promise<IAnimatedImageDecoder | null> {
+    const Ctor = getImageDecoderCtor();
+    if (!Ctor) {
+        return null;
+    }
+    try {
+        if (typeof Ctor.isTypeSupported === 'function' && !(await Ctor.isTypeSupported(mime))) {
+            return null;
+        }
+        const decoder = new Ctor({ data: bytes, type: mime });
+        await decoder.tracks.ready;
+        const track = decoder.tracks.selectedTrack;
+        if (!track || !track.frameCount) {
+            decoder.close();
+            return null;
+        }
+        // decode frame 0 to learn the display size.
+        const first = await decoder.decode({ frameIndex: 0 });
+        const width = first.image.displayWidth;
+        const height = first.image.displayHeight;
+        first.image.close();
+        const repetition = track.repetitionCount;
+        const loopCount = (repetition === Infinity || repetition < 0) ? 0 : repetition;
+        return new WebCodecsDecoder(decoder, width, height, track.frameCount, loopCount);
+    } catch (e) {
+        if (DEBUG) {
+            warn(`WebCodecs ImageDecoder failed, falling back to WASM: ${e}`);
+        }
+        return null;
+    }
+}
+
+export async function createAnimatedDecoder (bytes: Uint8Array, mime: string): Promise<IAnimatedImageDecoder> {
+    if (shouldForceWasm()) {
+        if (DEBUG) {
+            warn('[animated-image] __forceWebpWasmDecoder is on: skipping native WebCodecs and using the WASM fallback.');
+        }
+        if (isWasmDecoderSupported()) {
+            return createWasmDecoder(bytes);
+        }
+        if (DEBUG) {
+            warn('[animated-image] WASM fallback is unavailable; reverting to the native decoder.');
+        }
+    }
+    const native = await tryCreateNative(bytes, mime);
+    if (native) {
+        return native;
+    }
+    if (isWasmDecoderSupported()) {
+        return createWasmDecoder(bytes);
+    }
+    throw new Error(`No animated image decoder available for ${mime} on this platform.`);
+}
+
+checkPalIntegrity<typeof import('pal/image-decoder')>(withImpl<typeof import('./image-decoder-web')>());

--- a/pal/system-info/enum-type/feature.ts
+++ b/pal/system-info/enum-type/feature.ts
@@ -112,4 +112,12 @@ export enum Feature {
      * @zh 运行时检测是否支持 Webassembly，一般在宏 `NATIVE_CODE_BUNDLE_MODE` 为 2 时需要检测，如果不支持，需要回滚到 Asm 方案
      */
     WASM = 'WASM',
+    /**
+     * @en Feature to support native per-frame decoding of animated images (e.g. animated WebP), such as
+     * the WebCodecs `ImageDecoder` on Web. When unsupported, the engine falls back to the bundled libwebp
+     * WASM decoder, so animated images still play.
+     * @zh 是否支持原生逐帧解码动画图片（如动画 WebP），例如 Web 上的 WebCodecs `ImageDecoder`。
+     * 不支持时，引擎会回退到自带的 libwebp WASM 解码器，动画图片依然可以播放。
+     */
+    IMAGE_DECODER = 'IMAGE_DECODER',
 }

--- a/pal/system-info/minigame/system-info.ts
+++ b/pal/system-info/minigame/system-info.ts
@@ -271,6 +271,7 @@ class SystemInfo extends EventTarget {
             [Feature.EVENT_HMD]: this.isXR,
             [Feature.EVENT_HANDHELD]: false,
             [Feature.WASM]: supportWasm,
+            [Feature.IMAGE_DECODER]: false,
         };
 
         this._initPromise.push(this._supportsWebpPromise());

--- a/pal/system-info/native/system-info.ts
+++ b/pal/system-info/native/system-info.ts
@@ -136,6 +136,7 @@ class SystemInfo extends EventTarget {
             [Feature.EVENT_HANDHELD]: (typeof xr !== 'undefined' && typeof xr.ARModule !== 'undefined'),
             // Although the iOS OS supports WASM, the engine does not yet support loading WASM on this platform.
             [Feature.WASM]: !OPEN_HARMONY && !IOS,
+            [Feature.IMAGE_DECODER]: false,
         };
 
         this._registerEvent();

--- a/pal/system-info/nodejs/system-info.ts
+++ b/pal/system-info/nodejs/system-info.ts
@@ -106,6 +106,7 @@ class SystemInfo extends EventTarget {
             [Feature.EVENT_HMD]: false,
             [Feature.EVENT_HANDHELD]: false,
             [Feature.WASM]: true,
+            [Feature.IMAGE_DECODER]: false,
         };
 
     }

--- a/pal/system-info/web/system-info.ts
+++ b/pal/system-info/web/system-info.ts
@@ -250,6 +250,7 @@ class SystemInfo extends EventTarget {
             [Feature.EVENT_HMD]: supportXR,
             [Feature.EVENT_HANDHELD]: supportXR,
             [Feature.WASM]: supportWasm,
+            [Feature.IMAGE_DECODER]: typeof (globalThis as { ImageDecoder?: unknown }).ImageDecoder !== 'undefined',
         };
 
         this._initPromise.push(this._supportsImageBitmapPromise());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,7 @@
       "./native/external/emscripten/spine/spine",
       "./native/external/emscripten/meshopt/meshopt_decoder",
       "./native/external/emscripten/box2d/box2d",
+      "./native/external/emscripten/webp/webpxmux",
 
       // pal
       "./@types/pal/system-info",
@@ -49,7 +50,8 @@
       "./@types/pal/input",
       "./@types/pal/env",
       "./@types/pal/pacer",
-      "./@types/pal/wasm"
+      "./@types/pal/wasm",
+      "./@types/pal/image-decoder"
     ]
   },
   "include": [


### PR DESCRIPTION
Add a layered animated-image feature: a low-level AnimatedImagePlayer, an AnimatedImage component, and a pal/image-decoder PAL with per-platform backends. The web backend uses the native WebCodecs ImageDecoder with a bundled libwebp WASM fallback; other platforms fall back to WASM.

The AnimatedImage component plays on the sibling Sprite and accepts three sources: an ImageAsset (a webp imported the default way — recommended and default), a remote URL, or a local BufferAsset. Only the field relevant to the selected sourceType is shown in the inspector.

Also register the IMAGE_DECODER system-info feature, wire the pal mapping and animated-image module in cc.config.json, add the Feature Cropping entry and i18n, and include a runtime demo under docs/examples.

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
