### PR TITLE
fix(legacy): A2C (Alpha to Coverage) and (antialias or MSAA) are mutually exclusive

### DIFF
--- a/cocos/render-scene/core/pass.ts
+++ b/cocos/render-scene/core/pass.ts
@@ -148,11 +148,15 @@ export class Pass {
             //                        WebGL: antialias from gl.getContextAttributes(), since WebGL
             //                        MSAA is controlled at context level, not texture level)
             if (bs.isA2C) {
-                const gl: WebGL2RenderingContext | WebGLRenderingContext | null = (deviceManager.gfxDevice as any).gl ?? null;
-                const antialias = gl?.getContextAttributes()?.antialias ?? false;
-                const passWantsMultisample = info.rasterizerState?.isMultisample === true
+                const gfxDevice = deviceManager.gfxDevice as any;
+                const gl: WebGL2RenderingContext | WebGLRenderingContext | null = gfxDevice.gl || null;
+                const ctxAttrs = gl && gl.getContextAttributes();
+                const antialias: boolean = !!(ctxAttrs && ctxAttrs.antialias);
+                const passWantsMultisample = (info.rasterizerState && info.rasterizerState.isMultisample === true)
                     || pass._rs.isMultisample;
-                const globalMsaaEnabled = (deviceManager.swapchain?.colorTexture?.samples ?? SampleCount.X1) > SampleCount.X1
+                const swapchain = deviceManager.swapchain;
+                const colorTex = swapchain && swapchain.colorTexture;
+                const globalMsaaEnabled = (colorTex && colorTex.samples > SampleCount.X1)
                     || antialias;
                 if (!passWantsMultisample || !globalMsaaEnabled) {
                     bs.isA2C = false;

--- a/cocos/render-scene/core/pass.ts
+++ b/cocos/render-scene/core/pass.ts
@@ -31,7 +31,7 @@ import { murmurhash2_32_gc, errorID, assertID, cclegacy, warnID } from '../../co
 import {
     BufferUsageBit, DynamicStateFlagBit, DynamicStateFlags, Feature, GetTypeSize, MemoryUsageBit, PrimitiveMode, Type, Color,
     BlendState, BlendTarget, Buffer, BufferInfo, BufferViewInfo, DepthStencilState, DescriptorSet,
-    DescriptorSetInfo, DescriptorSetLayout, Device, RasterizerState, Sampler, Texture, Shader, PipelineLayout, deviceManager, UniformBlock,
+    DescriptorSetInfo, DescriptorSetLayout, Device, RasterizerState, Sampler, SampleCount, Texture, Shader, PipelineLayout, deviceManager, UniformBlock,
 } from '../../gfx';
 import { EffectAsset } from '../../asset/assets/effect-asset';
 import { IProgramInfo, programLib } from './program-lib';
@@ -142,10 +142,18 @@ export class Pass {
 
             // A2C (Alpha to Coverage) and alpha blending are mutually exclusive:
             // A2C converts alpha to MSAA coverage masks and is only meaningful for opaque rendering.
-            // When any blend target has blending enabled, A2C produces incorrect results
-            // (e.g. hard alpha cutoff at 0.5 instead of smooth transparency), so force it off.
-            if (bs.isA2C && bs.targets.some((t): boolean => t.blend)) {
-                bs.isA2C = false;
+            // Disable A2C when:
+            //   1. Any blend target has blending enabled (A2C causes hard alpha cutoff at ~0.5), OR
+            //   2. Neither the pass nor the global framebuffer has MSAA enabled
+            //      (A2C has no effect without multiple subsamples, behaves as alpha-test at 0.5).
+            if (bs.isA2C) {
+                const hasBlend = bs.targets.some((t): boolean => t.blend);
+                const passWantsMultisample = info.rasterizerState?.isMultisample === true
+                    || pass._rs.isMultisample;
+                const globalMsaaEnabled = (deviceManager.swapchain?.colorTexture?.samples ?? SampleCount.X1) > SampleCount.X1;
+                if (hasBlend || (!passWantsMultisample && !globalMsaaEnabled)) {
+                    bs.isA2C = false;
+                }
             }
         }
         pass._rs.assign(info.rasterizerState as RasterizerState);

--- a/cocos/render-scene/core/pass.ts
+++ b/cocos/render-scene/core/pass.ts
@@ -139,6 +139,14 @@ export class Pass {
             if (bsInfo.isA2C !== undefined) { bs.isA2C = bsInfo.isA2C; }
             if (bsInfo.isIndepend !== undefined) { bs.isIndepend = bsInfo.isIndepend; }
             if (bsInfo.blendColor !== undefined) { bs.blendColor = bsInfo.blendColor as Color; }
+
+            // A2C (Alpha to Coverage) and alpha blending are mutually exclusive:
+            // A2C converts alpha to MSAA coverage masks and is only meaningful for opaque rendering.
+            // When any blend target has blending enabled, A2C produces incorrect results
+            // (e.g. hard alpha cutoff at 0.5 instead of smooth transparency), so force it off.
+            if (bs.isA2C && bs.targets.some((t): boolean => t.blend)) {
+                bs.isA2C = false;
+            }
         }
         pass._rs.assign(info.rasterizerState as RasterizerState);
         pass._dss.assign(info.depthStencilState as DepthStencilState);

--- a/cocos/render-scene/core/pass.ts
+++ b/cocos/render-scene/core/pass.ts
@@ -140,18 +140,21 @@ export class Pass {
             if (bsInfo.isIndepend !== undefined) { bs.isIndepend = bsInfo.isIndepend; }
             if (bsInfo.blendColor !== undefined) { bs.blendColor = bsInfo.blendColor as Color; }
 
-            // A2C (Alpha to Coverage) and alpha blending are mutually exclusive:
-            // A2C converts alpha to MSAA coverage masks and is only meaningful for opaque rendering.
-            // Disable A2C when:
-            //   1. Any blend target has blending enabled (A2C causes hard alpha cutoff at ~0.5), OR
-            //   2. Neither the pass nor the global framebuffer has MSAA enabled
-            //      (A2C has no effect without multiple subsamples, behaves as alpha-test at 0.5).
+            // A2C (Alpha to Coverage) requires MSAA to be effective.
+            // Without multiple subsamples, A2C behaves like alpha-test at ~0.5 and should be disabled.
+            // Disable A2C when neither the pass nor the global framebuffer has MSAA enabled:
+            //   - passWantsMultisample: pass explicitly requests isMultisample
+            //   - globalMsaaEnabled: swapchain has MSAA (native: colorTexture.samples > X1;
+            //                        WebGL: antialias from gl.getContextAttributes(), since WebGL
+            //                        MSAA is controlled at context level, not texture level)
             if (bs.isA2C) {
-                const hasBlend = bs.targets.some((t): boolean => t.blend);
+                const gl: WebGL2RenderingContext | WebGLRenderingContext | null = (deviceManager.gfxDevice as any).gl ?? null;
+                const antialias = gl?.getContextAttributes()?.antialias ?? false;
                 const passWantsMultisample = info.rasterizerState?.isMultisample === true
                     || pass._rs.isMultisample;
-                const globalMsaaEnabled = (deviceManager.swapchain?.colorTexture?.samples ?? SampleCount.X1) > SampleCount.X1;
-                if (hasBlend || (!passWantsMultisample && !globalMsaaEnabled)) {
+                const globalMsaaEnabled = (deviceManager.swapchain?.colorTexture?.samples ?? SampleCount.X1) > SampleCount.X1
+                    || antialias;
+                if (!passWantsMultisample && !globalMsaaEnabled) {
                     bs.isA2C = false;
                 }
             }

--- a/cocos/render-scene/core/pass.ts
+++ b/cocos/render-scene/core/pass.ts
@@ -152,13 +152,12 @@ export class Pass {
                 const gl: WebGL2RenderingContext | WebGLRenderingContext | null = gfxDevice.gl || null;
                 const ctxAttrs = gl && gl.getContextAttributes();
                 const antialias: boolean = !!(ctxAttrs && ctxAttrs.antialias);
-                const passWantsMultisample = (info.rasterizerState && info.rasterizerState.isMultisample === true)
-                    || pass._rs.isMultisample;
+                const passWantsMultisample = (info.rasterizerState && info.rasterizerState.isMultisample === true);
                 const swapchain = deviceManager.swapchain;
                 const colorTex = swapchain && swapchain.colorTexture;
-                const globalMsaaEnabled = (colorTex && colorTex.samples > SampleCount.X1)
-                    || antialias;
-                if (!passWantsMultisample || !globalMsaaEnabled) {
+                const msaaDisabled = (!colorTex || (colorTex && colorTex.samples <= SampleCount.X1))
+                    || !antialias || !passWantsMultisample;
+                if (msaaDisabled) {
                     bs.isA2C = false;
                 }
             }

--- a/cocos/render-scene/core/pass.ts
+++ b/cocos/render-scene/core/pass.ts
@@ -154,7 +154,7 @@ export class Pass {
                     || pass._rs.isMultisample;
                 const globalMsaaEnabled = (deviceManager.swapchain?.colorTexture?.samples ?? SampleCount.X1) > SampleCount.X1
                     || antialias;
-                if (!passWantsMultisample && !globalMsaaEnabled) {
+                if (!passWantsMultisample || !globalMsaaEnabled) {
                     bs.isA2C = false;
                 }
             }

--- a/native/cocos/core/assets/EffectAsset.h
+++ b/native/cocos/core/assets/EffectAsset.h
@@ -364,6 +364,19 @@ struct BlendStateInfo {
         if (blendColor.has_value()) {
             bs.blendColor = blendColor.value();
         }
+
+        // A2C (Alpha to Coverage) and alpha blending are mutually exclusive:
+        // A2C converts alpha to MSAA coverage masks and is only meaningful for opaque rendering.
+        // When any blend target has blending enabled, A2C produces incorrect results
+        // (e.g. hard alpha cutoff at ~0.5 instead of smooth transparency), so force it off.
+        if (bs.isA2C) {
+            for (const auto &target : bs.targets) {
+                if (target.blend) {
+                    bs.isA2C = 0;
+                    break;
+                }
+            }
+        }
     }
 };
 

--- a/native/cocos/core/assets/EffectAsset.h
+++ b/native/cocos/core/assets/EffectAsset.h
@@ -364,19 +364,6 @@ struct BlendStateInfo {
         if (blendColor.has_value()) {
             bs.blendColor = blendColor.value();
         }
-
-        // A2C (Alpha to Coverage) and alpha blending are mutually exclusive:
-        // A2C converts alpha to MSAA coverage masks and is only meaningful for opaque rendering.
-        // When any blend target has blending enabled, A2C produces incorrect results
-        // (e.g. hard alpha cutoff at ~0.5 instead of smooth transparency), so force it off.
-        if (bs.isA2C) {
-            for (const auto &target : bs.targets) {
-                if (target.blend) {
-                    bs.isA2C = 0;
-                    break;
-                }
-            }
-        }
     }
 };
 

--- a/native/cocos/scene/Pass.cpp
+++ b/native/cocos/scene/Pass.cpp
@@ -120,16 +120,13 @@ void Pass::fillPipelineInfo(Pass *pass, const IPassInfoFull &info) {
     if (info.blendState.has_value()) {
         info.blendState.value().assignToGFXBlendState(pass->_blendState);
 
-        // Disable A2C when:
-        //   1. Any blend target has blending enabled (A2C and blend are mutually exclusive), OR
-        //   2. Neither the pass nor the global framebuffer has MSAA enabled
-        //      (A2C has no effect without multiple subsamples, behaves as alpha-test at ~0.5).
+        // A2C (Alpha to Coverage) requires MSAA to be effective.
+        // Without multiple subsamples, A2C behaves like alpha-test at ~0.5 and should be disabled.
+        // Disable A2C when neither the pass nor the global framebuffer has MSAA enabled:
+        //   - passWantsMultisample: pass explicitly requests isMultisample
+        //   - globalMsaaEnabled: swapchain colorTexture.samples > X1 (native backends only;
+        //                        WebGL MSAA is checked via gl.getContextAttributes() on the TS side)
         if (pass->_blendState.isA2C) {
-            bool hasBlend = false;
-            for (const auto &target : pass->_blendState.targets) {
-                if (target.blend) { hasBlend = true; break; }
-            }
-
             const bool passWantsMultisample =
                 (info.rasterizerState.has_value() && info.rasterizerState.value().isMultisample.has_value()
                     ? info.rasterizerState.value().isMultisample.value() != 0
@@ -144,7 +141,7 @@ void Pass::fillPipelineInfo(Pass *pass, const IPassInfoFull &info) {
                 }
             }
 
-            if (hasBlend || (!passWantsMultisample && !globalMsaaEnabled)) {
+            if (!passWantsMultisample && !globalMsaaEnabled) {
                 pass->_blendState.isA2C = 0;
             }
         }

--- a/native/cocos/scene/Pass.cpp
+++ b/native/cocos/scene/Pass.cpp
@@ -141,7 +141,7 @@ void Pass::fillPipelineInfo(Pass *pass, const IPassInfoFull &info) {
                 }
             }
 
-            if (!passWantsMultisample && !globalMsaaEnabled) {
+            if (!passWantsMultisample || !globalMsaaEnabled) {
                 pass->_blendState.isA2C = 0;
             }
         }

--- a/native/cocos/scene/Pass.cpp
+++ b/native/cocos/scene/Pass.cpp
@@ -119,6 +119,35 @@ void Pass::fillPipelineInfo(Pass *pass, const IPassInfoFull &info) {
 
     if (info.blendState.has_value()) {
         info.blendState.value().assignToGFXBlendState(pass->_blendState);
+
+        // Disable A2C when:
+        //   1. Any blend target has blending enabled (A2C and blend are mutually exclusive), OR
+        //   2. Neither the pass nor the global framebuffer has MSAA enabled
+        //      (A2C has no effect without multiple subsamples, behaves as alpha-test at ~0.5).
+        if (pass->_blendState.isA2C) {
+            bool hasBlend = false;
+            for (const auto &target : pass->_blendState.targets) {
+                if (target.blend) { hasBlend = true; break; }
+            }
+
+            const bool passWantsMultisample =
+                (info.rasterizerState.has_value() && info.rasterizerState.value().isMultisample.has_value()
+                    ? info.rasterizerState.value().isMultisample.value() != 0
+                    : pass->_rs.isMultisample != 0);
+
+            bool globalMsaaEnabled = false;
+            const auto *device = gfx::Device::getInstance();
+            if (device) {
+                const auto &swapchains = device->getSwapchains();
+                if (!swapchains.empty() && swapchains[0] && swapchains[0]->getColorTexture()) {
+                    globalMsaaEnabled = swapchains[0]->getColorTexture()->getInfo().samples > gfx::SampleCount::X1;
+                }
+            }
+
+            if (hasBlend || (!passWantsMultisample && !globalMsaaEnabled)) {
+                pass->_blendState.isA2C = 0;
+            }
+        }
     }
 
     if (info.rasterizerState.has_value()) {

--- a/native/cocos/scene/Pass.cpp
+++ b/native/cocos/scene/Pass.cpp
@@ -132,16 +132,16 @@ void Pass::fillPipelineInfo(Pass *pass, const IPassInfoFull &info) {
                     ? info.rasterizerState.value().isMultisample.value() != 0
                     : pass->_rs.isMultisample != 0);
 
-            bool globalMsaaEnabled = false;
+            bool msaaDisabled = true;
             const auto *device = gfx::Device::getInstance();
             if (device) {
                 const auto &swapchains = device->getSwapchains();
                 if (!swapchains.empty() && swapchains[0] && swapchains[0]->getColorTexture()) {
-                    globalMsaaEnabled = swapchains[0]->getColorTexture()->getInfo().samples > gfx::SampleCount::X1;
+                    msaaDisabled = (swapchains[0]->getColorTexture()->getInfo().samples <= gfx::SampleCount::X1) || !passWantsMultisample;
                 }
             }
 
-            if (!passWantsMultisample || !globalMsaaEnabled) {
+            if (msaaDisabled) {
                 pass->_blendState.isA2C = 0;
             }
         }


### PR DESCRIPTION
Re: #

### Changelog

* A2C (Alpha to Coverage) requires MSAA to be effective.
* Without multiple subsamples, A2C behaves like alpha-test at ~0.5 and should be disabled.
* Disable A2C when neither the pass nor the global framebuffer has MSAA enabled:
    - passWantsMultisample: pass explicitly requests isMultisample
    - globalMsaaEnabled: swapchain has MSAA (native: colorTexture.samples > X1;
            - WebGL: antialias from gl.getContextAttributes(), since WebGL
            - MSAA is controlled at context level, not texture level)

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
