### PR TITLE
fix(vulkan): fix split barrier events and general barrier submission

### DIFF
--- a/native/cocos/renderer/gfx-vulkan/VKCommandBuffer.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKCommandBuffer.cpp
@@ -892,7 +892,7 @@ void CCVKCommandBuffer::pipelineBarrier(const GeneralBarrier *barrier, const Buf
                 signalEvent(ccBuffer, gpuBarrier->srcStageMask);
             } else {
                 bool fullBarrier = ccBarrier->getInfo().type == BarrierType::FULL;
-                bool missed = _barrierEvents.find(ccBuffer) != _barrierEvents.end();
+                bool missed = _barrierEvents.find(ccBuffer) == _barrierEvents.end();
                 if (!fullBarrier && !missed) {
                     CC_ASSERT(_barrierEvents.find(ccBuffer) != _barrierEvents.end());
                     VkEvent event = _barrierEvents.at(ccBuffer);
@@ -966,8 +966,8 @@ void CCVKCommandBuffer::pipelineBarrier(const GeneralBarrier *barrier, const Buf
             }
         }
 
-        if (!fullBufferBarriers.empty() || !fullImageBarriers.empty()) {
-            vkCmdPipelineBarrier(_gpuCommandBuffer->vkCommandBuffer, fullSrcStageMask, fullDstStageMask, 0, 0, pMemoryBarrier,
+        if (!fullBufferBarriers.empty() || !fullImageBarriers.empty() || pMemoryBarrier) {
+            vkCmdPipelineBarrier(_gpuCommandBuffer->vkCommandBuffer, fullSrcStageMask, fullDstStageMask, 0, pMemoryBarrier ? 1 : 0, pMemoryBarrier,
                                  fullBufferBarriers.size(), fullBufferBarriers.data(), fullImageBarriers.size(), fullImageBarriers.data());
         }
     }


### PR DESCRIPTION
Re: #

### Changelog


- 修复 Vulkan buffer split barrier 的 event 判断错误。
  - 修正 `missed` 的判断逻辑，使其正确表示 buffer 是否缺少对应的 barrier event。

- 修复 Vulkan GeneralBarrier 未提交的问题。
  - 将 `pMemoryBarrier` 纳入 `vkCmdPipelineBarrier` 的调用条件。
  - 根据 `pMemoryBarrier` 是否存在，正确设置 `memoryBarrierCount`。
-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
