### PR TITLE
fix(legacy): sphere light has not lighting at LDR mode

### DIFF
--- a/cocos/render-scene/scene/point-light.ts
+++ b/cocos/render-scene/scene/point-light.ts
@@ -91,6 +91,9 @@ export class PointLight extends Light {
      * @en The luminance of the light source in LDR mode.
      * @zh LDR 模式下光源的亮度。
      */
+    get luminanceLDR (): number {
+        return this._luminanceLDR;
+    }
     set luminanceLDR (value: number) {
         this._luminanceLDR = value;
     }

--- a/cocos/render-scene/scene/sphere-light.ts
+++ b/cocos/render-scene/scene/sphere-light.ts
@@ -102,6 +102,9 @@ export class SphereLight extends Light {
      * @en The luminance of the light source in LDR mode
      * @zh LDR 模式下光源的亮度
      */
+    get luminanceLDR (): number {
+        return this._luminanceLDR;
+    }
     set luminanceLDR (value: number) {
         this._luminanceLDR = value;
     }


### PR DESCRIPTION
Re: #

### Changelog

* sphere-light.ts 中，luminanceLDR 只有 **setter** 没有 **getter**；而 updateUbo 却调用了未定义的 **getLuminanceLDR**，在 ts 中，未定义的 get 返回 undefine 传入到 GPU 就是NaN, 光照完全失效
* https://forum.cocos.org/t/topic/161540
* https://github.com/cocos/cocos-engine/issues/17631

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
