### PR TITLE
fix(rendering): skip environment specular sampling when IBL is disabled in reflection probe fallback

### DIFF
--- a/editor/assets/chunks/legacy/shading-standard-base.chunk
+++ b/editor/assets/chunks/legacy/shading-standard-base.chunk
@@ -222,7 +222,9 @@ vec4 CCStandardShadingBase (StandardSurface s, vec4 shadowPos) {
     vec3 R = normalize(reflect(-V, N));
     #if CC_USE_REFLECTION_PROBE == REFLECTION_PROBE_TYPE_CUBE
       if(s.reflectionProbeId < 0.0){
-        env = SampleReflectionProbe(cc_environment, R, s.roughness, cc_ambientGround.w, CC_USE_IBL == IBL_RGBE);
+        #if CC_USE_IBL
+          env = SampleReflectionProbe(cc_environment, R, s.roughness, cc_ambientGround.w, CC_USE_IBL == IBL_RGBE);
+        #endif
       }else{
         vec3 centerPos, boxHalfSize;
         float mipCount;
@@ -247,7 +249,9 @@ vec4 CCStandardShadingBase (StandardSurface s, vec4 shadowPos) {
       env = unpackRGBE(probe);
     #elif CC_USE_REFLECTION_PROBE == REFLECTION_PROBE_TYPE_BLEND || CC_USE_REFLECTION_PROBE == REFLECTION_PROBE_TYPE_BLEND_AND_SKYBOX
       if (s.reflectionProbeId < 0.0) {
-        env = SampleReflectionProbe(cc_environment, R, s.roughness, cc_ambientGround.w, CC_USE_IBL == IBL_RGBE);
+        #if CC_USE_IBL
+          env = SampleReflectionProbe(cc_environment, R, s.roughness, cc_ambientGround.w, CC_USE_IBL == IBL_RGBE);
+        #endif
       } else {
         vec3 centerPos, boxHalfSize;
         float mipCount;
@@ -256,7 +260,10 @@ vec4 CCStandardShadingBase (StandardSurface s, vec4 shadowPos) {
 
         env = SampleReflectionProbe(cc_reflectionProbeCubemap, fixedR.xyz, s.roughness, mipCount, isReflectProbeUsingRGBE(s.reflectionProbeId));
         if (s.reflectionProbeBlendId < 0.0) {
-          vec3 skyBoxEnv = SampleReflectionProbe(cc_environment, R, s.roughness, cc_ambientGround.w, CC_USE_IBL == IBL_RGBE) * lightIntensity;
+          vec3 skyBoxEnv = vec3(0.0);
+          #if CC_USE_IBL
+            skyBoxEnv = SampleReflectionProbe(cc_environment, R, s.roughness, cc_ambientGround.w, CC_USE_IBL == IBL_RGBE) * lightIntensity;
+          #endif
           #if CC_USE_REFLECTION_PROBE == REFLECTION_PROBE_TYPE_BLEND_AND_SKYBOX
             //blend with skybox
             env = mix(env, skyBoxEnv, s.reflectionProbeBlendFactor);

--- a/editor/assets/chunks/lighting-models/model-functions/standard-common.chunk
+++ b/editor/assets/chunks/lighting-models/model-functions/standard-common.chunk
@@ -99,7 +99,10 @@ vec3 SampleEnvironmentSpecular(samplerCube tex, in LightingIntermediateData ligh
     vec4 fixedR = CalculateBoxProjectedDirection(R, worldPos, cubeCenterPos, boxHalfSize);
     R = fixedR.xyz;
 
-    vec3 envmap = SampleEnvironmentSpecular(cc_environment, lightingData, cc_ambientGround.w).xyz * cc_ambientSky.w;
+    vec3 envmap = vec3(0.0);
+    #if CC_USE_IBL
+      envmap = SampleEnvironmentSpecular(cc_environment, lightingData, cc_ambientGround.w).xyz * cc_ambientSky.w;
+    #endif
     #if CC_SURFACES_LIGHTING_ANISOTROPIC && CC_SURFACES_LIGHTING_ANISOTROPIC_ENVCONVOLUTION_COUNT
       envSpec = EnvAnisotropicReflection(tex, fixedR.xyz, roughness, mipCount, lightingData.anisotropyShape, lightingData.V, lightingData.N, lightingData.T, lightingData.B);
       #if CC_USE_REFLECTION_PROBE == REFLECTION_PROBE_TYPE_CUBE
@@ -159,7 +162,9 @@ vec3 CalculateEnvironmentSpecular(in LightingIntermediateData lightingData, floa
 
   #if CC_USE_REFLECTION_PROBE == REFLECTION_PROBE_TYPE_CUBE
     if(FSInput_reflectionProbeId < 0.0){
+      #if CC_USE_IBL
         envSpec = SampleEnvironmentSpecular(cc_environment, lightingData, cc_ambientGround.w);
+      #endif
     }else{
       vec3 centerPos, boxHalfSize;
       float mipCount;
@@ -181,7 +186,9 @@ vec3 CalculateEnvironmentSpecular(in LightingIntermediateData lightingData, floa
     }
   #elif CC_USE_REFLECTION_PROBE == REFLECTION_PROBE_TYPE_BLEND || CC_USE_REFLECTION_PROBE == REFLECTION_PROBE_TYPE_BLEND_AND_SKYBOX
     if(FSInput_reflectionProbeId < 0.0){
+      #if CC_USE_IBL
         envSpec = SampleEnvironmentSpecular(cc_environment, lightingData, cc_ambientGround.w);
+      #endif
     }else{
       vec3 centerPos, boxHalfSize;
       float mipCount;
@@ -197,7 +204,10 @@ vec3 CalculateEnvironmentSpecular(in LightingIntermediateData lightingData, floa
 
       if(FSInput_reflectionProbeBlendId < 0.0)
       {
-        vec3 skyBoxEnv = SampleEnvironmentSpecular(cc_environment, lightingData, cc_ambientGround.w).rgb * lightIntensity;
+        vec3 skyBoxEnv = vec3(0.0);
+        #if CC_USE_IBL
+          vec3 skyBoxEnv = SampleEnvironmentSpecular(cc_environment, lightingData, cc_ambientGround.w).rgb * lightIntensity;
+        #endif
         #if CC_USE_REFLECTION_PROBE == REFLECTION_PROBE_TYPE_BLEND_AND_SKYBOX
           //blend with skybox
           envSpec = mix(envSpec, skyBoxEnv, blendFactor);

--- a/editor/assets/chunks/lighting-models/model-functions/standard-common.chunk
+++ b/editor/assets/chunks/lighting-models/model-functions/standard-common.chunk
@@ -206,7 +206,7 @@ vec3 CalculateEnvironmentSpecular(in LightingIntermediateData lightingData, floa
       {
         vec3 skyBoxEnv = vec3(0.0);
         #if CC_USE_IBL
-          vec3 skyBoxEnv = SampleEnvironmentSpecular(cc_environment, lightingData, cc_ambientGround.w).rgb * lightIntensity;
+          skyBoxEnv = SampleEnvironmentSpecular(cc_environment, lightingData, cc_ambientGround.w).rgb * lightIntensity;
         #endif
         #if CC_USE_REFLECTION_PROBE == REFLECTION_PROBE_TYPE_BLEND_AND_SKYBOX
           //blend with skybox


### PR DESCRIPTION
When skybox uses HEMISPHERE_DIFFUSE (CC_USE_IBL=0) and an object has
BAKED_CUBEMAP but is outside any probe's bounding box, the shader
incorrectly sampled cc_environment producing blue sky reflections.
Wrapped all fallback cc_environment sampling with #if CC_USE_IBL guards
so specular falls back to vec3(0.0) when IBL is off.

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
