### PR TITLE
fix:getCapabilities inheap assert

### DIFF
--- a/native/cocos/renderer/pipeline/custom/RenderCommonJsb.cpp
+++ b/native/cocos/renderer/pipeline/custom/RenderCommonJsb.cpp
@@ -32,6 +32,7 @@
 #include "cocos/bindings/auto/jsb_scene_auto.h"
 #include "cocos/renderer/pipeline/custom/RenderCommonJsb.h"
 #include "cocos/renderer/pipeline/custom/RenderCommonTypes.h"
+#include "cocos/renderer/pipeline/custom/RenderInterfaceTypes.h"
 #include "cocos/renderer/pipeline/custom/details/JsbConversion.h"
 
 bool nativevalue_to_se(const cc::render::LightInfo &from, se::Value &to, se::Object *ctx) { // NOLINT
@@ -49,6 +50,17 @@ bool nativevalue_to_se(const cc::render::LightInfo &from, se::Value &to, se::Obj
 
     nativevalue_to_se(from.culledByLight, tmp, ctx);
     obj->setProperty("culledByLight", tmp);
+
+    to.setObject(obj);
+    return true;
+}
+
+bool nativevalue_to_se(const cc::render::PipelineCapabilities &from, se::Value &to, se::Object *ctx) { // NOLINT
+    se::HandleObject obj(se::Object::createPlainObject());
+    se::Value        tmp;
+
+    nativevalue_to_se(from.subpass, tmp, ctx);
+    obj->setProperty("subpass", tmp);
 
     to.setObject(obj);
     return true;

--- a/native/cocos/renderer/pipeline/custom/RenderCommonJsb.h
+++ b/native/cocos/renderer/pipeline/custom/RenderCommonJsb.h
@@ -31,8 +31,11 @@
 #pragma once
 #include "cocos/bindings/manual/jsb_conversions.h"
 #include "cocos/renderer/pipeline/custom/RenderCommonFwd.h"
+#include "cocos/renderer/pipeline/custom/RenderInterfaceFwd.h"
 
 bool nativevalue_to_se(const cc::render::LightInfo &from, se::Value &to, se::Object *ctx); // NOLINT
+
+bool nativevalue_to_se(const cc::render::PipelineCapabilities &from, se::Value &to, se::Object *ctx); // NOLINT
 
 bool nativevalue_to_se(const cc::render::ResolvePair &from, se::Value &to, se::Object *ctx); // NOLINT
 


### PR DESCRIPTION
Re: #

- Fix inHeap assertion crash when Chrome DevTools inspects pipeline.capabilities property during breakpoint debugging
- Add nativevalue_to_se specialization for PipelineCapabilities struct, converting it to a plain JS object instead of falling through to native_ptr_to_seval

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
