### PR TITLE
fix(google-play): set PROP_MIN_SDK_VERSION to 24

### DIFF
--- a/templates/google-play/build/gradle.properties
+++ b/templates/google-play/build/gradle.properties
@@ -27,7 +27,8 @@ android.native.buildOutput=verbose
 PROP_COMPILE_SDK_VERSION=36
 
 # Android SDK version that will be used as the earliest version of android this application can run on
-PROP_MIN_SDK_VERSION=21
+# play-services-oss-licenses, introduced on Feb 2, 2026, requires minSdkVersion 24. https://developers.google.com/android/guides/releases
+PROP_MIN_SDK_VERSION=24
 
 # Android SDK version that will be used as the latest version of android this application has been tested on
 PROP_TARGET_SDK_VERSION=36


### PR DESCRIPTION
## Summary
- Bump `PROP_MIN_SDK_VERSION` from 21 to 24 in the Google Play template.
- `play-services-oss-licenses`, introduced on Feb 2, 2026, requires `minSdkVersion` 24. See https://developers.google.com/android/guides/releases

## Test plan
- [ ] Verify that `templates/google-play/build/gradle.properties` has `PROP_MIN_SDK_VERSION=24`
- [ ] https://zentao.sud.center/index.php?m=bug&f=view&bugID=859