### PR TITLE
perf: optimize instanced buffer batching

### DIFF
--- a/cocos/rendering/instanced-buffer.ts
+++ b/cocos/rendering/instanced-buffer.ts
@@ -54,6 +54,21 @@ export interface IInstancedItem {
     reflectionProbeBlendCubemap: Texture | null;
 }
 
+interface IInstancedCreateInfo {
+    key: string;
+    sourceIA: InputAssembler;
+    instancedAttributes: Attribute[];
+    instanceData: Uint8Array;
+    stride: number;
+    shader: Shader;
+    descriptorSet: DescriptorSet;
+    lightingMap: Texture;
+    reflectionProbeCubemap: Texture;
+    reflectionProbePlanarMap: Texture;
+    useReflectionProbeType: number;
+    reflectionProbeBlendCubemap: Texture | null;
+}
+
 const INITIAL_CAPACITY = 32;
 const MAX_CAPACITY = 1024;
 
@@ -65,6 +80,7 @@ export class InstancedBuffer {
     public sortRender: IRenderPass;
     private declare _passPool: RecyclePool<IRenderPass>;
     private declare _device: Device;
+    private readonly _instanceMap = new Map<string, IInstancedItem[]>();
     constructor (pass: Pass) {
         this._device = pass.device;
         this.pass = pass;
@@ -81,6 +97,7 @@ export class InstancedBuffer {
         });
         this._passPool.reset();
         this.instances.length = 0;
+        this._instanceMap.clear();
     }
 
     public merge (subModel: SubModel, passIdx: number, shaderImplant: Shader | null = null): void {
@@ -106,72 +123,102 @@ export class InstancedBuffer {
         this.sortRender.hash = hash;
         this.sortRender.shaderId = shader.typedID;
         this.sortRender.passIdx = passIdx;
-        for (let i = 0; i < this.instances.length; ++i) {
-            const instance = this.instances[i];
-            if (instance.ia.indexBuffer?.objectID !== sourceIA.indexBuffer?.objectID || instance.count >= MAX_CAPACITY) { continue; }
 
-            // check same binding
-            if (instance.lightingMap.objectID !== lightingMap.objectID) {
-                continue;
+        const probeBlendID = ENABLE_PROBE_BLEND ? reflectionProbeBlendCubemap!.objectID : 0;
+        const key = [
+            sourceIA.indexBuffer?.objectID ?? 0,
+            lightingMap.objectID,
+            useReflectionProbeType,
+            reflectionProbeCubemap.objectID,
+            reflectionProbePlanarMap.objectID,
+            probeBlendID,
+            stride,
+        ].join('/');
+        const mappedInstances = this._instanceMap.get(key);
+        if (mappedInstances) {
+            for (let i = 0; i < mappedInstances.length; ++i) {
+                const instance = mappedInstances[i];
+                if (instance.count >= MAX_CAPACITY) { continue; }
+                this._appendInstance(instance, attrs.buffer, shader, descriptorSet);
+                return;
             }
-
-            if (instance.useReflectionProbeType !== useReflectionProbeType) {
-                continue;
-            }
-            if (instance.reflectionProbeCubemap.objectID !== reflectionProbeCubemap.objectID) {
-                continue;
-            }
-            if (instance.reflectionProbePlanarMap.objectID !== reflectionProbePlanarMap.objectID) {
-                continue;
-            }
-            if (ENABLE_PROBE_BLEND && instance.reflectionProbeBlendCubemap!.objectID !== reflectionProbeBlendCubemap!.objectID) {
-                continue;
-            }
-
-            if (instance.stride !== stride) {
-                // we allow this considering both baked and non-baked
-                // skinning models may be present in the same buffer
-                continue;
-            }
-            if (instance.count >= instance.capacity) { // resize buffers
-                instance.capacity <<= 1;
-                const newSize = instance.stride * instance.capacity;
-                const oldData = instance.data;
-                instance.data = new Uint8Array(newSize);
-                instance.data.set(oldData);
-                instance.vb.resize(newSize);
-            }
-            instance.shader = shader;
-            instance.descriptorSet = descriptorSet;
-            instance.data.set(attrs.buffer, instance.stride * instance.count++);
-            this.hasPendingModels = true;
-            return;
         }
 
-        // Create a new instance
+        this._createInstance({
+            key,
+            sourceIA,
+            instancedAttributes: attrs.attributes,
+            instanceData: attrs.buffer,
+            stride,
+            shader,
+            descriptorSet,
+            lightingMap,
+            reflectionProbeCubemap,
+            reflectionProbePlanarMap,
+            useReflectionProbeType,
+            reflectionProbeBlendCubemap,
+        });
+    }
+
+    private _appendInstance (instance: IInstancedItem, data: Uint8Array, shader: Shader, descriptorSet: DescriptorSet): void {
+        if (instance.count >= instance.capacity) { // resize buffers
+            instance.capacity = Math.min(instance.capacity << 1, MAX_CAPACITY);
+            const newSize = instance.stride * instance.capacity;
+            const oldData = instance.data;
+            instance.data = new Uint8Array(newSize);
+            instance.data.set(oldData);
+            instance.vb.resize(newSize);
+        }
+        instance.shader = shader;
+        instance.descriptorSet = descriptorSet;
+        instance.data.set(data, instance.stride * instance.count++);
+        this.hasPendingModels = true;
+    }
+
+    private _createInstance (info: IInstancedCreateInfo): void {
         const vb = this._device.createBuffer(new BufferInfo(
             BufferUsageBit.VERTEX | BufferUsageBit.TRANSFER_DST,
             MemoryUsageBit.HOST | MemoryUsageBit.DEVICE,
-            stride * INITIAL_CAPACITY,
-            stride,
+            info.stride * INITIAL_CAPACITY,
+            info.stride,
         ));
-        const data = new Uint8Array(stride * INITIAL_CAPACITY);
-        const vertexBuffers = sourceIA.vertexBuffers.slice();
-        const attributes = sourceIA.attributes.slice();
-        const indexBuffer = sourceIA.indexBuffer;
+        const data = new Uint8Array(info.stride * INITIAL_CAPACITY);
+        const vertexBuffers = info.sourceIA.vertexBuffers.slice();
+        const attributes = info.sourceIA.attributes.slice();
+        const indexBuffer = info.sourceIA.indexBuffer;
 
-        for (let i = 0; i < attrs.attributes.length; i++) {
-            const attr = attrs.attributes[i];
+        for (let i = 0; i < info.instancedAttributes.length; i++) {
+            const attr = info.instancedAttributes[i];
             const newAttr = new Attribute(attr.name, attr.format, attr.isNormalized, vertexBuffers.length, true);
             attributes.push(newAttr);
         }
-        data.set(attrs.buffer);
+        data.set(info.instanceData);
 
         vertexBuffers.push(vb);
         const iaInfo = new InputAssemblerInfo(attributes, vertexBuffers, indexBuffer);
         const ia = this._device.createInputAssembler(iaInfo);
-        // eslint-disable-next-line max-len
-        this.instances.push({ count: 1, capacity: INITIAL_CAPACITY, vb, data, ia, stride, shader, descriptorSet, lightingMap, reflectionProbeCubemap, reflectionProbePlanarMap, useReflectionProbeType, reflectionProbeBlendCubemap });
+        const instance = {
+            count: 1,
+            capacity: INITIAL_CAPACITY,
+            vb,
+            data,
+            ia,
+            stride: info.stride,
+            shader: info.shader,
+            descriptorSet: info.descriptorSet,
+            lightingMap: info.lightingMap,
+            reflectionProbeCubemap: info.reflectionProbeCubemap,
+            reflectionProbePlanarMap: info.reflectionProbePlanarMap,
+            useReflectionProbeType: info.useReflectionProbeType,
+            reflectionProbeBlendCubemap: info.reflectionProbeBlendCubemap,
+        };
+        this.instances.push(instance);
+        let mappedInstances = this._instanceMap.get(info.key);
+        if (!mappedInstances) {
+            mappedInstances = [];
+            this._instanceMap.set(info.key, mappedInstances);
+        }
+        mappedInstances.push(instance);
         this.hasPendingModels = true;
     }
 
@@ -180,7 +227,7 @@ export class InstancedBuffer {
             const instance = this.instances[i];
             if (!instance.count) { continue; }
             instance.ia.instanceCount = instance.count;
-            cmdBuff.updateBuffer(instance.vb, instance.data);
+            cmdBuff.updateBuffer(instance.vb, instance.data.buffer as ArrayBuffer, instance.count * instance.stride);
         }
     }
 

--- a/cocos/rendering/instanced-buffer.ts
+++ b/cocos/rendering/instanced-buffer.ts
@@ -30,6 +30,7 @@ import { UNIFORM_LIGHTMAP_TEXTURE_BINDING, UNIFORM_REFLECTION_PROBE_BLEND_CUBEMA
     getPassPool } from './define';
 import { BufferUsageBit, MemoryUsageBit, Device, InputAssembler, InputAssemblerInfo,
     Attribute, Buffer, BufferInfo, CommandBuffer, Shader, DescriptorSet  } from '../gfx';
+import type { Texture } from '../gfx';
 import { RecyclePool } from '../core/memop';
 
 export function instancingCompareFn (l: InstancedBuffer, r: InstancedBuffer): number {
@@ -47,6 +48,11 @@ export interface IInstancedItem {
     stride: number;
     shader: Shader | null;
     descriptorSet: DescriptorSet;
+    lightingMap: Texture;
+    reflectionProbeCubemap: Texture;
+    reflectionProbePlanarMap: Texture;
+    useReflectionProbeType: number;
+    reflectionProbeBlendCubemap: Texture | null;
 }
 
 const INITIAL_CAPACITY = 32;
@@ -182,7 +188,7 @@ export class InstancedBuffer {
             stride,
             shader,
             descriptorSet,
-        };
+        } as IInstancedItem;
         this.instances.push(instance);
         let mappedInstances = this._instanceMap.get(key);
         if (!mappedInstances) {

--- a/cocos/rendering/instanced-buffer.ts
+++ b/cocos/rendering/instanced-buffer.ts
@@ -28,7 +28,7 @@ import { UNIFORM_LIGHTMAP_TEXTURE_BINDING, UNIFORM_REFLECTION_PROBE_BLEND_CUBEMA
     UNIFORM_REFLECTION_PROBE_TEXTURE_BINDING, ENABLE_PROBE_BLEND,
     IRenderPass,
     getPassPool } from './define';
-import { BufferUsageBit, MemoryUsageBit, Device, Texture, InputAssembler, InputAssemblerInfo,
+import { BufferUsageBit, MemoryUsageBit, Device, InputAssembler, InputAssemblerInfo,
     Attribute, Buffer, BufferInfo, CommandBuffer, Shader, DescriptorSet  } from '../gfx';
 import { RecyclePool } from '../core/memop';
 
@@ -47,11 +47,6 @@ export interface IInstancedItem {
     stride: number;
     shader: Shader | null;
     descriptorSet: DescriptorSet;
-    lightingMap: Texture;
-    reflectionProbeCubemap: Texture;
-    reflectionProbePlanarMap: Texture;
-    useReflectionProbeType: number;
-    reflectionProbeBlendCubemap: Texture | null;
 }
 
 const INITIAL_CAPACITY = 32;
@@ -130,11 +125,6 @@ export class InstancedBuffer {
             stride,
             shader,
             descriptorSet,
-            lightingMap,
-            reflectionProbeCubemap,
-            reflectionProbePlanarMap,
-            useReflectionProbeType,
-            reflectionProbeBlendCubemap,
         );
     }
 
@@ -161,11 +151,6 @@ export class InstancedBuffer {
         stride: number,
         shader: Shader,
         descriptorSet: DescriptorSet,
-        lightingMap: Texture,
-        reflectionProbeCubemap: Texture,
-        reflectionProbePlanarMap: Texture,
-        useReflectionProbeType: number,
-        reflectionProbeBlendCubemap: Texture | null,
     ): void {
         const vb = this._device.createBuffer(new BufferInfo(
             BufferUsageBit.VERTEX | BufferUsageBit.TRANSFER_DST,
@@ -197,11 +182,6 @@ export class InstancedBuffer {
             stride,
             shader,
             descriptorSet,
-            lightingMap,
-            reflectionProbeCubemap,
-            reflectionProbePlanarMap,
-            useReflectionProbeType,
-            reflectionProbeBlendCubemap,
         };
         this.instances.push(instance);
         let mappedInstances = this._instanceMap.get(key);

--- a/cocos/rendering/instanced-buffer.ts
+++ b/cocos/rendering/instanced-buffer.ts
@@ -54,21 +54,6 @@ export interface IInstancedItem {
     reflectionProbeBlendCubemap: Texture | null;
 }
 
-interface IInstancedCreateInfo {
-    key: string;
-    sourceIA: InputAssembler;
-    instancedAttributes: Attribute[];
-    instanceData: Uint8Array;
-    stride: number;
-    shader: Shader;
-    descriptorSet: DescriptorSet;
-    lightingMap: Texture;
-    reflectionProbeCubemap: Texture;
-    reflectionProbePlanarMap: Texture;
-    useReflectionProbeType: number;
-    reflectionProbeBlendCubemap: Texture | null;
-}
-
 const INITIAL_CAPACITY = 32;
 const MAX_CAPACITY = 1024;
 
@@ -124,16 +109,9 @@ export class InstancedBuffer {
         this.sortRender.shaderId = shader.typedID;
         this.sortRender.passIdx = passIdx;
 
-        const probeBlendID = ENABLE_PROBE_BLEND ? reflectionProbeBlendCubemap!.objectID : 0;
-        const key = [
-            sourceIA.indexBuffer?.objectID ?? 0,
-            lightingMap.objectID,
-            useReflectionProbeType,
-            reflectionProbeCubemap.objectID,
-            reflectionProbePlanarMap.objectID,
-            probeBlendID,
-            stride,
-        ].join('/');
+        const key = `${sourceIA.indexBuffer?.objectID ?? 0}/${lightingMap.objectID}/${useReflectionProbeType}/`
+            + `${reflectionProbeCubemap.objectID}/${reflectionProbePlanarMap.objectID}/`
+            + `${ENABLE_PROBE_BLEND ? reflectionProbeBlendCubemap!.objectID : 0}/${stride}`;
         const mappedInstances = this._instanceMap.get(key);
         if (mappedInstances) {
             for (let i = 0; i < mappedInstances.length; ++i) {
@@ -144,11 +122,11 @@ export class InstancedBuffer {
             }
         }
 
-        this._createInstance({
+        this._createInstance(
             key,
             sourceIA,
-            instancedAttributes: attrs.attributes,
-            instanceData: attrs.buffer,
+            attrs.attributes,
+            attrs.buffer,
             stride,
             shader,
             descriptorSet,
@@ -157,7 +135,7 @@ export class InstancedBuffer {
             reflectionProbePlanarMap,
             useReflectionProbeType,
             reflectionProbeBlendCubemap,
-        });
+        );
     }
 
     private _appendInstance (instance: IInstancedItem, data: Uint8Array, shader: Shader, descriptorSet: DescriptorSet): void {
@@ -175,24 +153,37 @@ export class InstancedBuffer {
         this.hasPendingModels = true;
     }
 
-    private _createInstance (info: IInstancedCreateInfo): void {
+    private _createInstance (
+        key: string,
+        sourceIA: InputAssembler,
+        instancedAttributes: Attribute[],
+        instanceData: Uint8Array,
+        stride: number,
+        shader: Shader,
+        descriptorSet: DescriptorSet,
+        lightingMap: Texture,
+        reflectionProbeCubemap: Texture,
+        reflectionProbePlanarMap: Texture,
+        useReflectionProbeType: number,
+        reflectionProbeBlendCubemap: Texture | null,
+    ): void {
         const vb = this._device.createBuffer(new BufferInfo(
             BufferUsageBit.VERTEX | BufferUsageBit.TRANSFER_DST,
             MemoryUsageBit.HOST | MemoryUsageBit.DEVICE,
-            info.stride * INITIAL_CAPACITY,
-            info.stride,
+            stride * INITIAL_CAPACITY,
+            stride,
         ));
-        const data = new Uint8Array(info.stride * INITIAL_CAPACITY);
-        const vertexBuffers = info.sourceIA.vertexBuffers.slice();
-        const attributes = info.sourceIA.attributes.slice();
-        const indexBuffer = info.sourceIA.indexBuffer;
+        const data = new Uint8Array(stride * INITIAL_CAPACITY);
+        const vertexBuffers = sourceIA.vertexBuffers.slice();
+        const attributes = sourceIA.attributes.slice();
+        const indexBuffer = sourceIA.indexBuffer;
 
-        for (let i = 0; i < info.instancedAttributes.length; i++) {
-            const attr = info.instancedAttributes[i];
+        for (let i = 0; i < instancedAttributes.length; i++) {
+            const attr = instancedAttributes[i];
             const newAttr = new Attribute(attr.name, attr.format, attr.isNormalized, vertexBuffers.length, true);
             attributes.push(newAttr);
         }
-        data.set(info.instanceData);
+        data.set(instanceData);
 
         vertexBuffers.push(vb);
         const iaInfo = new InputAssemblerInfo(attributes, vertexBuffers, indexBuffer);
@@ -203,20 +194,20 @@ export class InstancedBuffer {
             vb,
             data,
             ia,
-            stride: info.stride,
-            shader: info.shader,
-            descriptorSet: info.descriptorSet,
-            lightingMap: info.lightingMap,
-            reflectionProbeCubemap: info.reflectionProbeCubemap,
-            reflectionProbePlanarMap: info.reflectionProbePlanarMap,
-            useReflectionProbeType: info.useReflectionProbeType,
-            reflectionProbeBlendCubemap: info.reflectionProbeBlendCubemap,
+            stride,
+            shader,
+            descriptorSet,
+            lightingMap,
+            reflectionProbeCubemap,
+            reflectionProbePlanarMap,
+            useReflectionProbeType,
+            reflectionProbeBlendCubemap,
         };
         this.instances.push(instance);
-        let mappedInstances = this._instanceMap.get(info.key);
+        let mappedInstances = this._instanceMap.get(key);
         if (!mappedInstances) {
             mappedInstances = [];
-            this._instanceMap.set(info.key, mappedInstances);
+            this._instanceMap.set(key, mappedInstances);
         }
         mappedInstances.push(instance);
         this.hasPendingModels = true;


### PR DESCRIPTION
Re: #

### Changelog

* Optimized instanced buffer batching by caching compatible instance groups to avoid repeatedly scanning all existing instance groups.
* Reduced instance buffer upload size by uploading only the valid instance data range instead of the whole allocated buffer.
* Refactored instance creation and append logic to make the instanced buffer update path clearer and easier to maintain.

### Performance

This change optimizes the existing instancing path without changing when instancing is enabled. Materials still need to enable `USE_INSTANCING` explicitly.

Before this change, each incoming instanced model searched through all existing instance groups linearly to find a compatible group. As the number of instance groups increased, the CPU cost of `InstancedBuffer.merge()` grew accordingly.

After this change, compatible instance groups are cached by a key generated from the input assembler, lighting map, reflection probe textures, reflection probe type, and instance attribute stride. This allows the merge path to quickly find candidate groups and only scan groups that share the same compatibility key.

In addition, buffer uploads now use the valid instance data size, `instance.count * instance.stride`, instead of uploading the whole allocated backing buffer. This avoids uploading unused capacity when the instance buffer has grown but is not fully occupied.

Before profiling result:
<img width="1470" height="863" alt="1" src="https://github.com/user-attachments/assets/c6ea79ca-6e6a-421b-83ae-ed4c97306c4e" />

<img width="1309" height="760" alt="3" src="https://github.com/user-attachments/assets/e7ddf9e9-8dd0-4b6b-b9c6-d44b07bc79b4" />


 After profiling result:
<img width="1470" height="863" alt="2" src="https://github.com/user-attachments/assets/b2235450-bb49-4e3e-a037-3e2950913199" />

[
<img width="1279" height="748" alt="4" src="https://github.com/user-attachments/assets/1e075164-6350-469f-a690-ca79adb4c747" />
](url)


-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->

### Test Plan

- Verified a scene with many mesh renderers using the same mesh and material with `USE_INSTANCING` enabled.
- Verified that all instances render correctly before and after this change.
- Verified that non-instancing materials are not affected.
- Verified that instances with different IA, lighting map, reflection probe textures, reflection probe type, or instance attribute stride are not merged together.
- Verified that exceeding one instanced buffer capacity creates another compatible instance group correctly.
- Verified that partial buffer upload works correctly after the buffer grows and the valid instance count becomes smaller in later frames.
- Compared Chrome DevTools CPU profiles before and after this change and confirmed that `InstancedBuffer.merge()` cost is reduced.
