### PR TITLE
fix punctual lights visibility issue with custom pipeline (#270)

### DIFF
--- a/cocos/rendering/custom/scene-culling.ts
+++ b/cocos/rendering/custom/scene-culling.ts
@@ -556,7 +556,11 @@ export class SceneCulling {
 
     private executeSphereLightCulling (light: SphereLight, frustumCullingResult: Array<Model>, lightBoundsCullingResult: Array<Model>): void {
         const lightAABB = light.aabb;
+        const visibility = light.visibility;
         for (const model of frustumCullingResult) {
+            if (!isVisible(model, visibility)) {
+                continue;
+            }
             const modelBounds = model.worldBounds;
             if (!modelBounds || intersect.aabbWithAABB(modelBounds, lightAABB)) {
                 lightBoundsCullingResult.push(model);
@@ -567,7 +571,11 @@ export class SceneCulling {
     private executeSpotLightCulling (light: SpotLight, frustumCullingResult: Array<Model>, lightBoundsCullingResult: Array<Model>): void {
         const lightAABB = light.aabb;
         const lightFrustum: Frustum = light.frustum;
+        const visibility = light.visibility;
         for (const model of frustumCullingResult) {
+            if (!isVisible(model, visibility)) {
+                continue;
+            }
             const modelBounds = model.worldBounds;
             if (!modelBounds || (intersect.aabbWithAABB(lightAABB, modelBounds) && intersect.aabbFrustum(modelBounds, lightFrustum))) {
                 lightBoundsCullingResult.push(model);
@@ -577,7 +585,11 @@ export class SceneCulling {
 
     private executePointLightCulling (light: PointLight, frustumCullingResult: Array<Model>, lightBoundsCullingResult: Array<Model>): void {
         const lightAABB = light.aabb;
+        const visibility = light.visibility;
         for (const model of frustumCullingResult) {
+            if (!isVisible(model, visibility)) {
+                continue;
+            }
             const modelBounds = model.worldBounds;
             if (!modelBounds || intersect.aabbWithAABB(lightAABB, modelBounds)) {
                 lightBoundsCullingResult.push(model);
@@ -590,8 +602,12 @@ export class SceneCulling {
         frustumCullingResult: Array<Model>,
         lightBoundsCullingResult: Array<Model>,
     ): void {
+        const visibility = light.visibility;
         rangedDirLightBoundingBox.transform(light.node!.worldMatrix, null, null, null, lightAABB);
         for (const model of frustumCullingResult) {
+            if (!isVisible(model, visibility)) {
+                continue;
+            }
             const modelBounds = model.worldBounds;
             if (!modelBounds || intersect.aabbWithAABB(lightAABB, modelBounds)) {
                 lightBoundsCullingResult.push(model);

--- a/native/cocos/renderer/pipeline/custom/NativeSceneCulling.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativeSceneCulling.cpp
@@ -224,6 +224,10 @@ uint32_t isModelVisible(const scene::Model& model, uint32_t visibility) {
     return visibility & static_cast<uint32_t>(model.getVisFlags());
 }
 
+uint32_t isVisible(const scene::Model& model, uint32_t visibility) {
+    return isNodeVisible(model.getNode(), visibility) || isModelVisible(model, visibility);
+}
+
 bool isReflectProbeMask(const scene::Model& model) {
     return ((model.getNode()->getLayer() & REFLECTION_PROBE_DEFAULT_MASK) == model.getNode()->getLayer()) ||
            (REFLECTION_PROBE_DEFAULT_MASK & static_cast<uint32_t>(model.getVisFlags()));
@@ -432,8 +436,12 @@ void executeSphereLightCulling(
     const ccstd::vector<const scene::Model*>& frustumCullingResult,
     ccstd::vector<const scene::Model*>& lightBoundsCullingResult) {
     const auto& lightAABB = light.getAABB();
+    const auto visibility = light.getVisibility();
     for (const auto* const model : frustumCullingResult) {
         CC_EXPECTS(model);
+        if (!isVisible(*model, visibility)) {
+            continue;
+        }
         const auto* const modelBounds = model->getWorldBounds();
         if (!modelBounds || modelBounds->aabbAabb(lightAABB)) {
             lightBoundsCullingResult.emplace_back(model);
@@ -447,8 +455,12 @@ void executeSpotLightCulling(
     ccstd::vector<const scene::Model*>& lightBoundsCullingResult) {
     const auto& lightAABB = light.getAABB();
     const auto& lightFrustum = light.getFrustum();
+    const auto visibility = light.getVisibility();
     for (const auto* const model : frustumCullingResult) {
         CC_EXPECTS(model);
+        if (!isVisible(*model, visibility)) {
+            continue;
+        }
         const auto* const modelBounds = model->getWorldBounds();
         if (!modelBounds || (modelBounds->aabbAabb(lightAABB) && modelBounds->aabbFrustum(lightFrustum))) {
             lightBoundsCullingResult.emplace_back(model);
@@ -461,8 +473,12 @@ void executePointLightCulling(
     const ccstd::vector<const scene::Model*>& frustumCullingResult,
     ccstd::vector<const scene::Model*>& lightBoundsCullingResult) {
     const auto& lightAABB = light.getAABB();
+    const auto visibility = light.getVisibility();
     for (const auto* const model : frustumCullingResult) {
         CC_EXPECTS(model);
+        if (!isVisible(*model, visibility)) {
+            continue;
+        }
         const auto* const modelBounds = model->getWorldBounds();
         if (!modelBounds || modelBounds->aabbAabb(lightAABB)) {
             lightBoundsCullingResult.emplace_back(model);
@@ -479,8 +495,12 @@ void executeRangedDirectionalLightCulling(
     // light->getNode()->updateWorldTransform();
     geometry::AABB lightAABB{};
     rangedDirLightBoundingBox.transform(light.getNode()->getWorldMatrix(), &lightAABB);
+    const auto visibility = light.getVisibility();
     for (const auto* const model : frustumCullingResult) {
         CC_EXPECTS(model);
+        if (!isVisible(*model, visibility)) {
+            continue;
+        }
         const auto* const modelBounds = model->getWorldBounds();
         if (!modelBounds || modelBounds->aabbAabb(lightAABB)) {
             lightBoundsCullingResult.emplace_back(model);


### PR DESCRIPTION
Re: #

### Changelog

* 自定义管线中没有处理light visibility导致光源无法筛选作用的物体类别。

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
