### PR TITLE
Revert "fix: exclude spine 4.2 third-party files from clang-format"

### DIFF
--- a/.github/workflows/native-clang-format.yml
+++ b/.github/workflows/native-clang-format.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: DoozyX/clang-format-lint-action@v0.18
       with:
         source: ./native
-        exclude: './native/cocos/bindings/auto ./native/cocos/editor-support/spine'
+        exclude: ./native/cocos/bindings/auto
         extensions: 'c,h,hpp,cpp,cxx'
         style: file
         inplace: true

--- a/native/.clang-format-ignore
+++ b/native/.clang-format-ignore
@@ -1,6 +1,5 @@
 # ignore third_party code from clang-format checks
 ./cocos/bindings/auto/*
-./cocos/editor-support/spine/*
 ./cocos/gi/light-probe/predicates.cpp
 ./cocos/gi/light-probe/tetgen.cpp
 ./cocos/gi/light-probe/tetgen.h


### PR DESCRIPTION
Reverts cocos/cocos4#273