### PR TITLE
try fixing previous clang format ignore

### DIFF
--- a/.github/workflows/native-clang-format.yml
+++ b/.github/workflows/native-clang-format.yml
@@ -26,15 +26,10 @@ jobs:
         output: ' '
         fileOutput: ' '
 
-    - name: Echo change files
-      run: |
-        cat $HOME/files.txt
-        mv $HOME/files.txt ${{github.workspace}}/files.txt
-    
     - uses: DoozyX/clang-format-lint-action@v0.18
       with:
         source: ./native
-        exclude: ./native/cocos/bindings/auto
+        exclude: ./native/cocos/bindings/auto ./native/cocos/base/std ./native/cocos/editor-support/spine-wasm ./native/cocos/editor-support/spine ./native/cocos/gi/light-probe/predicates.cpp ./native/cocos/gi/light-probe/tetgen.cpp ./native/cocos/gi/light-probe/tetgen.h ./native/cocos/platform/openharmony/napi ./native/tools ./native/vendor
         extensions: 'c,h,hpp,cpp,cxx'
         style: file
         inplace: true

--- a/native/.clang-format-ignore
+++ b/native/.clang-format-ignore
@@ -1,5 +1,11 @@
 # ignore third_party code from clang-format checks
 ./cocos/bindings/auto/*
+./cocos/base/std/**
+./cocos/editor-support/spine-wasm/**
+./cocos/editor-support/spine/**
 ./cocos/gi/light-probe/predicates.cpp
 ./cocos/gi/light-probe/tetgen.cpp
 ./cocos/gi/light-probe/tetgen.h
+./cocos/platform/openharmony/napi/**
+./tools/**
+./vendor/**


### PR DESCRIPTION
cocos robot提交clang format代码时，忽视自动生成的文件。

## 测试方法
无需测试，用于github CI流程

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
