### PR TITLE
fix ios build problem

### DIFF
--- a/native/external-config.json
+++ b/native/external-config.json
@@ -3,6 +3,6 @@
         "type": "github",
         "owner": "cocos",
         "name": "cocos-engine-external",
-        "checkout": "v4.0.0-7"
+        "checkout": "v4.0.0-8"
     }
 }

--- a/native/external-config.json
+++ b/native/external-config.json
@@ -3,6 +3,6 @@
         "type": "github",
         "owner": "cocos",
         "name": "cocos-engine-external",
-        "checkout": "v4.0.0-8"
+        "checkout": "v4.0.0-9"
     }
 }

--- a/scripts/native-pack-tool/source/platforms/ios.ts
+++ b/scripts/native-pack-tool/source/platforms/ios.ts
@@ -1,9 +1,9 @@
-import { execSync, spawn } from 'child_process';
+import { execSync } from 'child_process';
 import * as fs from 'fs-extra';
 import * as ps from 'path';
 import * as os from 'os';
 import { CocosParams } from '../base/default';
-import { cchelper, toolHelper, Paths } from "../utils";
+import { cchelper, toolHelper } from "../utils";
 import { MacOSPackTool } from "./mac-os";
 
 export interface IOrientation {
@@ -115,13 +115,8 @@ export class IOSPackTool extends MacOSPackTool {
             throw new Error("Error: Try to build iphoneos application but no developer team id was given!");
         }
         const nativePrjDir = this.paths.nativePrjDir;
-
+        const simulatorArch = this.getIosSimulatorArch();
         const projName = this.params.projectName;
-        const os = require('os');
-        const cpus = os.cpus();
-        const model = (cpus && cpus[0] && cpus[0].model) ? cpus[0].model : '';
-        // check mac architecture
-        // const platform = /Apple/.test(model) ? `-arch arm64` : `-arch x86_64`;
         // get xcode workspace
         const regex = new RegExp(projName + '.xcworkspace$');
         const files = fs.readdirSync(nativePrjDir);
@@ -145,7 +140,7 @@ export class IOSPackTool extends MacOSPackTool {
                 await toolHelper.runCmake([projCompileParams, '-sdk', 'iphoneos', `-arch arm64`]);
             }
             if (options.simulator) {
-                await toolHelper.runCmake([projCompileParams, '-sdk', 'iphonesimulator', `-arch x86_64`]); //force compile x86_64 app for iPhone simulator on Mac
+                await toolHelper.runCmake([projCompileParams, '-sdk', 'iphonesimulator', `-arch ${simulatorArch}`]);
             }
         }
         return true;

--- a/scripts/native-pack-tool/source/platforms/mac-os.ts
+++ b/scripts/native-pack-tool/source/platforms/mac-os.ts
@@ -51,15 +51,49 @@ export abstract class MacOSPackTool extends NativePackTool {
         return /Apple/.test(model) && process.platform === 'darwin';
     }
 
-    protected getXcodeMajorVerion(): number {
+    protected compareVersion(a: string, b: string): number {
+        const aParts = a.split('.').map((part) => Number.parseInt(part, 10) || 0);
+        const bParts = b.split('.').map((part) => Number.parseInt(part, 10) || 0);
+        const maxLength = Math.max(aParts.length, bParts.length);
+
+        for (let i = 0; i < maxLength; i++) {
+            const aValue = aParts[i] ?? 0;
+            const bValue = bParts[i] ?? 0;
+            if (aValue !== bValue) {
+                return aValue - bValue;
+            }
+        }
+
+        return 0;
+    }
+
+    protected getXcodeVersion(): string {
         try {
             const output = execSync('xcrun xcodebuild -version').toString('utf8');
-            return Number.parseInt(output.match(/Xcode\s(\d+)\.\d+/)![1]);
+            const match = output.match(/Xcode\s+(\d+(?:\.\d+)+)/);
+            return match?.[1] || '0.0';
+        } catch (e) {
+            console.error(e);
+            return '0.0';
+        }
+    }
+
+    protected getXcodeMajorVerion(): number {
+        try {
+            return Number.parseInt(this.getXcodeVersion().split('.')[0] || '0', 10);
         } catch (e) {
             console.error(e);
             // fallback to default Xcode version
             return 11;
         }
+    }
+
+    protected getIosSimulatorArch(): 'arm64' | 'x86_64' {
+        // Xcode 14.3+ no longer supports running iOS Simulator under Rosetta on Apple Silicon.
+        if (this.isAppleSilicon() && this.compareVersion(this.getXcodeVersion(), '14.3') >= 0) {
+            return 'arm64';
+        }
+        return 'x86_64';
     }
 
     async modifyXcodeProject() {

--- a/templates/cmake/common.cmake
+++ b/templates/cmake/common.cmake
@@ -6,7 +6,7 @@ endif()
 
 if(POLICY CMP0111)
 # https://cmake.org/cmake/help/latest/policy/CMP0111.html
-cmake_policy(SET CMP0111 OLD)
+cmake_policy(SET CMP0111 NEW)
 endif()
 
 # set(CC_REGISTERED_PLUGINS)

--- a/templates/ios/CMakeLists.txt
+++ b/templates/ios/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.28)
 
 set(CMAKE_SYSTEM_NAME iOS)
 set(APP_NAME "CocosGame"  CACHE STRING "Project Name")

--- a/templates/mac/CMakeLists.txt
+++ b/templates/mac/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.28)
 
 set(APP_NAME "CocosGame" CACHE STRING "Project Name")
 option(ENABLE_SANDBOX "enable sandbox  entitlements.plist" ON)


### PR DESCRIPTION
Re: #
- cmake compile deprecated warn
- fix(ios): select simulator arch based on Xcode version

### Changelog

*

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
