### PR TITLE
fix(rendering): compute render pass merge info in render graph order

### DIFF
--- a/cocos/rendering/custom/compiler.ts
+++ b/cocos/rendering/custom/compiler.ts
@@ -22,7 +22,6 @@
  THE SOFTWARE.
 ****************************************************************************/
 import { Buffer, Framebuffer, Texture, Viewport } from '../../gfx';
-import { genHashValue } from './define';
 import { VectorGraphColorMap } from './effect';
 import { DefaultVisitor, depthFirstSearch, ReferenceGraphView } from './graph';
 import { LayoutGraphData } from './layout-graph';
@@ -199,7 +198,6 @@ class PassVisitor implements RenderGraphVisitor {
                     resourceGraph.visitVertex(this._resVisitor, vertID);
                 }
             }
-            genHashValue(pass);
         }
     }
     applyID (id: number, resId: number): void {

--- a/cocos/rendering/custom/web-pipeline.ts
+++ b/cocos/rendering/custom/web-pipeline.ts
@@ -1663,13 +1663,16 @@ export class WebPipeline extends WebSetter implements BasicPipeline {
                 this._compiler = new Compiler(this, this._renderGraph, this._resourceGraph, this._lg);
             }
             this._compiler.compile(this._renderGraph);
-        } else {
-            this._renderGraph.x.forEach((vert) => {
-                if (vert.t === RenderGraphValue.RasterPass) {
-                    genHashValue(vert.j as RasterPass);
-                }
-            });
         }
+        this._renderGraph.x.forEach((vert, v) => {
+            if (vert.t !== RenderGraphValue.RasterPass) {
+                return;
+            }
+            if (DEBUG && !this._renderGraph!.getValid(v)) {
+                return;
+            }
+            genHashValue(vert.j as RasterPass);
+        });
     }
 
     execute (): void {


### PR DESCRIPTION
In debug mode, pass hashes are generated while traversing the resource graph during compilation, so the render-pass merge bookkeeping (needBeginRP/needEndRP) can be computed in a different order from the actual execution order. When passes are reused, this can cause draw commands to be recorded outside a render pass and rejected by the validator.

Compute hashes after compilation by iterating the render graph vertices in execution order, and only include valid raster passes in debug mode.

Refs cocos/cocos4#156

Re: #

### Changelog

*

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
