### PR TITLE
When copying the old buffer value, if the old value is `undefined` (o…

### DIFF
--- a/cocos/terrain/terrain.ts
+++ b/cocos/terrain/terrain.ts
@@ -1819,7 +1819,7 @@ export class Terrain extends Component {
             return null;
         }
 
-        return this._layerList[id] ?? null;
+        return this._layerList[id] || null;
     }
 
     /**

--- a/cocos/terrain/terrain.ts
+++ b/cocos/terrain/terrain.ts
@@ -1815,11 +1815,11 @@ export class Terrain extends Component {
      * @zh 获得纹理层
      */
     public getLayer (id: number): TerrainLayer | null {
-        if (id === -1) {
+        if (id === -1 || id === undefined) {
             return null;
         }
 
-        return this._layerList[id];
+        return this._layerList[id] ?? null;
     }
 
     /**
@@ -2584,7 +2584,8 @@ export class Terrain extends Component {
                 const index1 = j * this.blockCount[0] + i;
 
                 for (let l = 0; l < TERRAIN_MAX_BLEND_LAYERS; ++l) {
-                    layerBuffer[index0 * TERRAIN_MAX_BLEND_LAYERS + l] = this._layerBuffer[index1 * TERRAIN_MAX_BLEND_LAYERS + l];
+                    const oldVal = this._layerBuffer[index1 * TERRAIN_MAX_BLEND_LAYERS + l];
+                    layerBuffer[index0 * TERRAIN_MAX_BLEND_LAYERS + l] = oldVal !== undefined ? oldVal : -1;
                 }
             }
         }


### PR DESCRIPTION
Re: #

### Changelog

error：
TypeError: Cannot read properties of undefined (reading 'tileSize')
    at TerrainBlock.update (terrain.ts:539:46)
    at Terrain.update (terrain.ts:1752:29)
    at component-scheduler.ts:299:35
    at ReusableInvoker._invoke (component-scheduler.ts:251:13)
    at ReusableInvoker.invoke (component-scheduler.ts:213:14)
    at ComponentScheduler.updatePhase (component-scheduler.ts:504:28)
    at Director.tick (director.ts:780:37)
    at Game._updateCallback (game.ts:1086:22)
    at Pacer.updateCallback [as _ccprivate$_callback] (pacer-web.js:4:1650)


*When `terrain.rebuild(info)` is called while the node is inactive, `_layerBuffer` is still an empty array `[]`. When `_rebuildLayerBuffer` copies data from this empty array, `undefined` overwrites the pre‑initialized `-1` values in the new buffer. Later, `TerrainBlock.update()` receives `undefined` as the layer ID. `getLayer(undefined)` returns `undefined` (not `null`), which bypasses the `!== null` check, eventually causing a crash when accessing `undefined.tileSize`.

Two fixes:

1. **_rebuildLayerBuffer (root‑cause fix)**: When copying old buffer values, if the old value is `undefined` (out‑of‑bounds access on an empty array), preserve the default `-1` instead of writing `undefined`.

2. **getLayer (defensive fix)**: Return `null` when `_layerList[id]` is `undefined`, and filter cases where `id === undefined`. Ensure the caller’s `!== null` check works correctly for interception.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->


TEST REQUEST: terrain_dynamic_create regression check (engine before/after)

Goal
Run the terrain_dynamic_create auto test case located in the
cocos-test-projects repo against two engine versions of Cocos and verify
the behavior difference below.

Versions to compare
- BEFORE (old engine, e.g. Creator 3.8.8 built-in engine): test is expected to FAIL
- AFTER (local cocos4 engine): test is expected to PASS

Acceptance
- On the OLD engine: terrain_dynamic_create FAILs (per-frame error captured)
- On the NEW engine: terrain_dynamic_create PASSes
