### PR TITLE
fix(particle): 修复二维粒子重新开启预览后不播放的问题

### DIFF
--- a/cocos/particle-2d/particle-system-2d.ts
+++ b/cocos/particle-2d/particle-system-2d.ts
@@ -522,8 +522,13 @@ export class ParticleSystem2D extends UIRenderer {
     }
 
     public set preview (val: boolean) {
-        if (val) { this._startPreview(); } else { this._stopPreview(); }
-        this._preview = val;
+        if (val) {
+            this._preview = true;
+            this._startPreview();
+        } else {
+            this._stopPreview();
+            this._preview = false;
+        }
     }
 
     /**

--- a/tests/particle/preview-2d.test.ts
+++ b/tests/particle/preview-2d.test.ts
@@ -1,0 +1,40 @@
+import { Node } from '../../cocos/scene-graph';
+import { ParticleSystem2D } from '../../cocos/particle-2d/particle-system-2d';
+
+describe('ParticleSystem2D editor preview', () => {
+    let node: Node;
+    let particles: ParticleSystem2D;
+
+    beforeEach(() => {
+        node = new Node('particles');
+        particles = node.addComponent(ParticleSystem2D)!;
+    });
+
+    afterEach(() => {
+        node.destroy();
+    });
+
+    test('restarts emission when preview is enabled again without changing selection', () => {
+        particles.preview = true;
+        expect(particles.active).toBe(true);
+
+        for (let cycle = 0; cycle < 3; ++cycle) {
+            particles.preview = false;
+            expect(particles.active).toBe(false);
+            particles.preview = true;
+            expect(particles.active).toBe(true);
+        }
+    });
+
+    test('keeps preview disabled on focus and preserves focus restart when enabled', () => {
+        particles.preview = false;
+        particles.onFocusInEditor();
+        expect(particles.active).toBe(false);
+
+        particles.preview = true;
+        particles.onLostFocusInEditor();
+        expect(particles.active).toBe(false);
+        particles.onFocusInEditor();
+        expect(particles.active).toBe(true);
+    });
+});


### PR DESCRIPTION
- **解决的问题**：2D 粒子关闭 Preview 后重新开启，粒子无法恢复播放，需要重新选中节点才会出现。
- **解决方式**：调整 Preview setter 的执行顺序，开启时先更新预览状态，再启动粒子，避免被旧的关闭状态拦截；关闭时保留原有清理顺序，并补充连续开关和焦点切换的回归测试。
